### PR TITLE
Use a personal access token for automerging PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,4 +14,4 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PAT}}


### PR DESCRIPTION
https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854

### Change description ###



