### PR TITLE
Fix boot performance regression

### DIFF
--- a/lib/rse-cft-lib/src/main/java/uk/gov/hmcts/rse/ccd/lib/LibRunner.java
+++ b/lib/rse-cft-lib/src/main/java/uk/gov/hmcts/rse/ccd/lib/LibRunner.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.rse.ccd.lib;
 
 import java.io.File;
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;


### PR DESCRIPTION
Start polling for started docker dependencies before running docker
compose, since frequently they will already be running and we don't want
to wait for docker-compose up.




