### PR TITLE
Remove AM from composite builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,5 +7,14 @@ gradle.includedBuilds.each {
     }
 }
 
+// TODO: rework all included projects away from composite builds.
+task publishAM(type: Exec) {
+    workingDir project.file('projects/am-role-assignment-service').path
+    commandLine './gradlew', '-i', '-I', project.file('init.gradle').path, 'publishToMavenLocal'
+    doFirst {
+        // Gradle requires this in nested builds.
+        project.file('projects/am-role-assignment-service/settings.gradle').createNewFile()
+    }
+}
 
-publish.dependsOn ':projects:definition-store-fat:doPublish'
+publish.dependsOn ':projects:definition-store-fat:doPublish', publishAM

--- a/init.gradle
+++ b/init.gradle
@@ -1,4 +1,3 @@
-
 def configurePublishing(p) {
     p.configure(p, {
         apply plugin: 'java'

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,6 @@ pluginManagement {
     }
 }
 
-includeBuild 'projects/am-role-assignment-service'
 includeBuild 'projects/ccd-definition-store-api'
 includeBuild 'projects/ccd-data-store-api'
 includeBuild 'projects/ccd-user-profile-api'


### PR DESCRIPTION
AM now requires Gradle 7 and other builds need 6 so we cannot have a
single composite build any more.

### Change description ###



