### PR TITLE
Add more memory to the code cache

### DIFF
--- a/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/LibRunnerTask.java
+++ b/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/LibRunnerTask.java
@@ -83,6 +83,6 @@ public class LibRunnerTask extends JavaExec {
       jvmArgs("--add-opens", "java.base/" + x + "=ALL-UNNAMED");
     });
     jvmArgs("--add-opens", "java.desktop/java.awt.font=ALL-UNNAMED");
-    jvmArgs("-XX:ReservedCodeCacheSize=64m");
+    jvmArgs("-XX:ReservedCodeCacheSize=128m");
   }
 }


### PR DESCRIPTION
### Change description ###

Bump memory to avoid: 
```
OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.
OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=
[9.177s][warning][codecache] Try increasing the code cache size using -XX:ReservedCodeCacheSize=
CodeCache: size=65536Kb used=65535Kb max_used=65535Kb free=0Kb
 bounds [0x00007ff7ac76f000, 0x00007ff7b076f000, 0x00007ff7b076f000]
 total_blobs=34966 nmethods=33828 adapters=1056
 compilation: disabled (not enough contiguous free space left)
              stopped_count=1, restarted_count=0
 full_count=0
 ```

