### PR TITLE
Decompose gradle composite build for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	path = projects/ccd-data-store-api
 	url = git@github.com:hmcts/ccd-data-store-api.git
 [submodule "projects/ccd-user-profile-api"]
-	path = projects/ccd-user-profile-api
+	path = projects/user-profile-api
 	url = git@github.com:hmcts/ccd-user-profile-api.git
 [submodule "projects/aac-manage-case-assignment"]
 	path = projects/aac-manage-case-assignment

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,9 @@ task publish
 project.file('projects').listFiles().each { dir ->
     if (!(dir.name =~ /definition-store/)) {
         def t = task "publish${dir.name}"(type: Exec) {
+            // Enable Gradle's up-to-date checks so we only rebuild the git submodules if they change.
+            inputs.property('sha', ['git', 'submodule', 'status', "projects/${dir.name}"].execute().text)
+            outputs.dir project.repositories.mavenLocal().url
             workingDir dir
             commandLine './gradlew', '-i', '-I', project.file('init.gradle').path, 'publishToMavenLocal'
             doFirst {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@ apply plugin: 'base'
 
 task publish
 
+// Create Gradle tasks that build and publish the CFT submodule projects to maven local.
+// We invoke each subproject's build separately using its own Gradle wrapper since each
+// project may require a different Gradle version.
 project.file('projects').listFiles().each { dir ->
     if (!(dir.name =~ /definition-store/)) {
         def t = task "publish${dir.name}"(type: Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,23 +2,22 @@ apply plugin: 'idea'
 apply plugin: 'base'
 
 task publish
-gradle.includedBuilds.each {
-    if (it.name != 'ccd-definition-store-api') {
-        publish.dependsOn it.task(':publishToMavenLocal')
+
+project.file('projects').listFiles().each { dir ->
+    if (!(dir.name =~ /definition-store/)) {
+        def t = task "publish${dir.name}"(type: Exec) {
+            workingDir dir
+            commandLine './gradlew', '-i', '-I', project.file('init.gradle').path, 'publishToMavenLocal'
+            doFirst {
+                // Gradle requires this in nested builds.
+                new File(dir, 'settings.gradle').createNewFile()
+            }
+        }
+        publish.dependsOn t
     }
 }
 
-// TODO: rework all included projects away from composite builds.
-task publishAM(type: Exec) {
-    workingDir project.file('projects/am-role-assignment-service').path
-    commandLine './gradlew', '-i', '-I', project.file('init.gradle').path, 'publishToMavenLocal'
-    doFirst {
-        // Gradle requires this in nested builds.
-        project.file('projects/am-role-assignment-service/settings.gradle').createNewFile()
-    }
-}
-
-publish.dependsOn ':projects:definition-store-fat:doPublish', publishAM
+publish.dependsOn ':projects:definition-store-fat:doPublish'
 
 tasks.check.dependsOn gradle.includedBuild('rse-cft-lib-plugin').task(':check')
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,9 @@ project.file('projects').listFiles().each { dir ->
         def t = task "publish${dir.name}"(type: Exec) {
             // Enable Gradle's up-to-date checks so we only rebuild the git submodules if they change.
             // Up to date checks require inputs and outputs to be defined, so we use the submodule's git tag as input
-            // and the maven local folder as output.
+            // and the maven local folder of the project as output.
             inputs.property('sha', ['git', 'submodule', 'status', "projects/${dir.name}"].execute().text)
-            outputs.dir project.repositories.mavenLocal().url
+            outputs.dir "${project.repositories.mavenLocal().url}/com/github/hmcts/rse-cft-lib/${dir.name}-lib"
             workingDir dir
             commandLine './gradlew', '-i', '-I', project.file('init.gradle').path, 'publishToMavenLocal'
             doFirst {

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,12 @@ task publish
 // We invoke each subproject's build separately using its own Gradle wrapper since each
 // project may require a different Gradle version.
 project.file('projects').listFiles().each { dir ->
+    // TODO: remove special casing for definition store when we merge def store into a single-module project.
     if (!(dir.name =~ /definition-store/)) {
         def t = task "publish${dir.name}"(type: Exec) {
             // Enable Gradle's up-to-date checks so we only rebuild the git submodules if they change.
+            // Up to date checks require inputs and outputs to be defined, so we use the submodule's git tag as input
+            // and the maven local folder as output.
             inputs.property('sha', ['git', 'submodule', 'status', "projects/${dir.name}"].execute().text)
             outputs.dir project.repositories.mavenLocal().url
             workingDir dir

--- a/init.gradle
+++ b/init.gradle
@@ -86,7 +86,7 @@ def importedProjects = [
 
 allprojects {
 
-  if (System.env.RSE_LOCAL_BUILD) {
+  if (!System.env.CI) {
     // Speed up the build when working locally
     if (project.hasProperty('dependencyManagement')) {
       configure(project) {

--- a/init.gradle
+++ b/init.gradle
@@ -86,16 +86,20 @@ def importedProjects = [
 
 allprojects {
 
-  if (!System.env.CI) {
-    // Speed up the build when working locally
-    if (project.hasProperty('dependencyManagement')) {
-      configure(project) {
-        dependencyManagement {
-          applyMavenExclusions = false
+    afterEvaluate {
+        if (!System.env.CI) {
+            // Speed up the build when working locally
+            // Spring boot's dependency management plugin's dependency exclusion feature
+            // can drastically slow down dependency resolution by repeatedly parsing POM files.
+            if (project.hasProperty('dependencyManagement')) {
+                configure(project) {
+                    dependencyManagement {
+                        applyMavenExclusions = false
+                    }
+                }
+            }
         }
-      }
     }
-  }
 
     def name = project.parent?.name ?: project.name
     if (importedProjects.contains(name)) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,10 +6,6 @@ pluginManagement {
 }
 
 includeBuild 'projects/ccd-definition-store-api'
-includeBuild 'projects/ccd-data-store-api'
-includeBuild 'projects/ccd-user-profile-api'
-includeBuild 'projects/aac-manage-case-assignment'
-includeBuild 'projects/ccd-case-document-am-api'
 includeBuild 'rse-cft-lib-plugin'
 include 'projects:definition-store-fat'
 include 'test-project'


### PR DESCRIPTION
### Change description ###

We previously used Gradle's composite build feature to bring the git submodules into a single gradle build, but this breaks when those submodules depend on different and incompatible gradle versions.

This change moves away from composite builds so we now invoke each submodule's gradle build to publish them as libraries to the maven local repo.



