### PR TITLE
Restore support for Gradle 6.x

### DIFF
--- a/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftLibPlugin.java
+++ b/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftLibPlugin.java
@@ -145,10 +145,7 @@ public class CftLibPlugin implements Plugin<Project> {
     }
 
     private Configuration detachedConfiguration(Project project, Dependency... deps) {
-        var result = project.getConfigurations().detachedConfiguration(deps);
-        // We don't want Gradle to swap in dependency substitutions in composite builds.
-        result.getResolutionStrategy().getUseGlobalDependencySubstitutionRules().set(false);
-        return result;
+        return project.getConfigurations().detachedConfiguration(deps);
     }
 
     /**


### PR DESCRIPTION
Remove use of a Gradle 7 API that we no longer need since moving the submodules away from Gradle composite builds.

TODO - run the tests on a specific version of Gradle using Gradle's testkit.



