### PR TITLE
Synced default value for SERVICES_PRD_COMMONDATA_API with rpx-xui-webapp

### DIFF
--- a/cftlib/lib/runtime/compose/docker-compose.yml
+++ b/cftlib/lib/runtime/compose/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       LAUNCH_DARKLY_CLIENT_ID: "${XUI_LD_ID:-5de6610b23ce5408280f2268}"
       SERVICES_ROLE_ASSIGNMENT_API: http://${JVM_HOST:-host.docker.internal}:4096
       HEALTH_ROLE_ASSIGNMENT_API: http://${JVM_HOST:-host.docker.internal}:4096/health
-      SERVICES_PRD_COMMONDATA_API: "${SERVICES_PRD_COMMONDATA_API:-http://rd-commondata-api-aat.service.core-compute-aat.internal}"
+      SERVICES_PRD_COMMONDATA_API: "${SERVICES_PRD_COMMONDATA_API}"
     ports:
       - ${XUI_PORT:-3000}:3000
     extra_hosts:

--- a/cftlib/lib/runtime/compose/docker-compose.yml
+++ b/cftlib/lib/runtime/compose/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       LAUNCH_DARKLY_CLIENT_ID: "${XUI_LD_ID:-5de6610b23ce5408280f2268}"
       SERVICES_ROLE_ASSIGNMENT_API: http://${JVM_HOST:-host.docker.internal}:4096
       HEALTH_ROLE_ASSIGNMENT_API: http://${JVM_HOST:-host.docker.internal}:4096/health
-      SERVICES_PRD_COMMONDATA_API: "${SERVICES_PRD_COMMONDATA_API}"
+      SERVICES_PRD_COMMONDATA_API: ${SERVICES_PRD_COMMONDATA_API}
     ports:
       - ${XUI_PORT:-3000}:3000
     extra_hosts:

--- a/cftlib/lib/runtime/compose/docker-compose.yml
+++ b/cftlib/lib/runtime/compose/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       LAUNCH_DARKLY_CLIENT_ID: "${XUI_LD_ID:-5de6610b23ce5408280f2268}"
       SERVICES_ROLE_ASSIGNMENT_API: http://${JVM_HOST:-host.docker.internal}:4096
       HEALTH_ROLE_ASSIGNMENT_API: http://${JVM_HOST:-host.docker.internal}:4096/health
-      SERVICES_PRD_COMMONDATA_API: "${SERVICES_PRD_COMMONDATA_API:-http://host.docker.internal:8765}"
+      SERVICES_PRD_COMMONDATA_API: "${SERVICES_PRD_COMMONDATA_API:-http://rd-commondata-api-aat.service.core-compute-aat.internal}"
     ports:
       - ${XUI_PORT:-3000}:3000
     extra_hosts:


### PR DESCRIPTION
### Change description ###

A previous change of mine added the ability to pass through SERVICES_PRD_COMMONDATA_API to xui, but the default value has unexpectedly affected other teams. This PR removes setting a default so that the envvar doesn't get passed through if not set