### PR TITLE
Point XUI work allocation URL to AAT instead of Prod

### DIFF
--- a/cftlib/lib/runtime/compose/docker-compose.yml
+++ b/cftlib/lib/runtime/compose/docker-compose.yml
@@ -80,8 +80,8 @@ services:
       SERVICES_ROLE_ASSIGNMENT_API: http://${JVM_HOST:-host.docker.internal}:4096
       HEALTH_ROLE_ASSIGNMENT_API: http://${JVM_HOST:-host.docker.internal}:4096/health
       SERVICES_PRD_COMMONDATA_API: ${SERVICES_PRD_COMMONDATA_API}
-      SERVICES_WORK_ALLOCATION_TASK_API: "${XUI_SERVICE_WA_TASK_API}:-http://wa-task-management-api-aat.service.core-compute-aat.internal}"
-      HEALTH_WORK_ALLOCATION_TASK_API: "${XUI_SERVICE_WA_TASK_API}:-http://wa-task-management-api-aat.service.core-compute-aat.internal}/health"
+      SERVICES_WORK_ALLOCATION_TASK_API: "http://wa-task-management-api-aat.service.core-compute-aat.internal"
+      HEALTH_WORK_ALLOCATION_TASK_API: "http://wa-task-management-api-aat.service.core-compute-aat.internal/health"
     ports:
       - ${XUI_PORT:-3000}:3000
     extra_hosts:

--- a/cftlib/lib/runtime/compose/docker-compose.yml
+++ b/cftlib/lib/runtime/compose/docker-compose.yml
@@ -80,6 +80,8 @@ services:
       SERVICES_ROLE_ASSIGNMENT_API: http://${JVM_HOST:-host.docker.internal}:4096
       HEALTH_ROLE_ASSIGNMENT_API: http://${JVM_HOST:-host.docker.internal}:4096/health
       SERVICES_PRD_COMMONDATA_API: ${SERVICES_PRD_COMMONDATA_API}
+      SERVICES_WORK_ALLOCATION_TASK_API: "${XUI_SERVICE_WA_TASK_API}:-http://wa-task-management-api-aat.service.core-compute-aat.internal}"
+      HEALTH_WORK_ALLOCATION_TASK_API: "${XUI_SERVICE_WA_TASK_API}:-http://wa-task-management-api-aat.service.core-compute-aat.internal}/health"
     ports:
       - ${XUI_PORT:-3000}:3000
     extra_hosts:
@@ -138,4 +140,3 @@ services:
       SIMULATOR_JWT_ISSUER: "${IDAM_SIMULATOR_BASE_URL:-http://localhost:5062}"
       SIMULATOR_OPENID_BASE-URL: "${IDAM_SIMULATOR_BASE_URL:-http://localhost:5062}"
       SERVER_PORT: 5062
-


### PR DESCRIPTION
### Change description ###
XUI have a default.json file which is pointing to production instance for work-allocation. CFT Lib can override this by setting an env var for that environment.



