### PR TITLE
Update ComposeRunner.java

### DIFF
--- a/cftlib/lib/runtime/src/main/java/uk/gov/hmcts/rse/ccd/lib/ComposeRunner.java
+++ b/cftlib/lib/runtime/src/main/java/uk/gov/hmcts/rse/ccd/lib/ComposeRunner.java
@@ -72,7 +72,7 @@ public class ComposeRunner {
             .redirectError(System.err)
             .directory(dir.toFile())
             .exitValueNormal()
-            .timeout(10, TimeUnit.MINUTES)
+            .timeout(30, TimeUnit.MINUTES)
             .execute();
 
     }


### PR DESCRIPTION
### Change description ###

Increased Docker Compose Runner timeout from 10 mins to 30 mins

