### PR TITLE
Fix request filter on Spring boot 3

### DIFF
--- a/cftlib/lib/bootstrapper/build.gradle
+++ b/cftlib/lib/bootstrapper/build.gradle
@@ -1,16 +1,6 @@
-java {
-    withJavadocJar()
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-}
 
 dependencies {
-
     // Dependency free to avoid polluting the system classloader.
-
-    // Use JUnit test framework
-    testImplementation 'junit:junit:4.13.2'
 }
 
 

--- a/cftlib/lib/build.gradle
+++ b/cftlib/lib/build.gradle
@@ -39,4 +39,11 @@ subprojects {
     }
 
     rootProject.tasks.publish.dependsOn(project.tasks.publishToMavenLocal)
+
+    java {
+        withJavadocJar()
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(17))
+        }
+    }
 }

--- a/cftlib/lib/cftlib-agent/build.gradle
+++ b/cftlib/lib/cftlib-agent/build.gradle
@@ -4,10 +4,14 @@ repositories {
 }
 
 // Used to compile classes for Spring Boot 3 that cannot be compiled with a Spring Boot 2 classpath.
-// These are all packaged into the same jar and @ConditionalOnClass is used to load the correct class for
+// These are all packaged into the same jar and @Conditional annotations are used to load the correct class for
 // the spring boot version in use.
 sourceSets {
     springBoot3
+}
+
+jar {
+    from sourceSets.springBoot3.output
 }
 
 dependencies {
@@ -68,6 +72,3 @@ configurations.each {
     it.resolutionStrategy.useGlobalDependencySubstitutionRules = false
 }
 
-jar {
-    from sourceSets.springBoot3.output
-}

--- a/cftlib/lib/cftlib-agent/build.gradle
+++ b/cftlib/lib/cftlib-agent/build.gradle
@@ -3,6 +3,13 @@ repositories {
     mavenLocal()
 }
 
+// Used to compile classes for Spring Boot 3 that cannot be compiled with a Spring Boot 2 classpath.
+// These are all packaged into the same jar and @ConditionalOnClass is used to load the correct class for
+// the spring boot version in use.
+sourceSets {
+    springBoot3
+}
+
 dependencies {
     // All these dependencies will be provided at runtime by the service this
     // library is injected into.
@@ -15,6 +22,14 @@ dependencies {
     compileOnly 'com.github.hmcts:service-auth-provider-java-client:4.0.2'
     compileOnly 'org.springframework.security:spring-security-oauth2-jose:5.4.9'
 
+    springBoot3CompileOnly 'org.springframework.boot:spring-boot:3.2.0'
+    springBoot3CompileOnly 'org.springframework.boot:spring-boot-autoconfigure:3.2.0'
+    springBoot3CompileOnly group: 'org.springframework', name: 'spring-web', version: '6.1.3'
+    springBoot3CompileOnly 'jakarta.servlet:jakarta.servlet-api:6.0.0'
+
+    springBoot3CompileOnly('com.github.hmcts:idam-java-client:2.0.1') {
+        transitive = false
+    }
 
     compileOnly('com.github.hmcts:idam-java-client:2.0.1') {
         transitive = false
@@ -53,8 +68,6 @@ configurations.each {
     it.resolutionStrategy.useGlobalDependencySubstitutionRules = false
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
+jar {
+    from sourceSets.springBoot3.output
 }

--- a/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot2RequestFilter.java
+++ b/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot2RequestFilter.java
@@ -33,11 +33,14 @@ public class SpringBoot2RequestFilter extends OncePerRequestFilter {
 
     private final String name;
 
+    private final boolean isCCD;
+
     @Autowired
     public SpringBoot2RequestFilter(IdamApi idam,
                                     @Value("${rse.lib.service_name:***CFT lib***}") String name) {
         this.idam = idam;
         this.name = name;
+        this.isCCD = name.toLowerCase().contains("ccd");
     }
 
     @Override
@@ -46,7 +49,9 @@ public class SpringBoot2RequestFilter extends OncePerRequestFilter {
         String name = Thread.currentThread().getName();
         try {
             Thread.currentThread().setName("*** " + this.name);
-            filterChain.doFilter(new Rewriter(request), response);
+            // Only emulate the CCD gateway for CCD services
+            request = isCCD ? new Rewriter(request) : request;
+            filterChain.doFilter(request, response);
         } finally {
             Thread.currentThread().setName(name);
         }

--- a/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot2RequestFilter.java
+++ b/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot2RequestFilter.java
@@ -17,12 +17,14 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import uk.gov.hmcts.reform.idam.client.IdamApi;
 
 /**
+ * Names threads for easier debugging.
  * Implements URL remappings handled by the CCD API Gateway.
+ * TODO: delete this and consolidate the springBoot3 sourceset when we can drop support for Spring Boot 2.
  */
 @Order(value = Ordered.HIGHEST_PRECEDENCE)
 @ConditionalOnClass({IdamApi.class, HttpServletRequest.class})
 @Component
-public class URLRewriter extends OncePerRequestFilter {
+public class SpringBoot2RequestFilter extends OncePerRequestFilter {
 
     @Autowired
     private final IdamApi idam;
@@ -30,8 +32,8 @@ public class URLRewriter extends OncePerRequestFilter {
     private final String name;
 
     @Autowired
-    public URLRewriter(IdamApi idam,
-                       @Value("${rse.lib.service_name:***CFT lib***}") String name) {
+    public SpringBoot2RequestFilter(IdamApi idam,
+                                    @Value("${rse.lib.service_name:***CFT lib***}") String name) {
         this.idam = idam;
         this.name = name;
     }

--- a/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot2RequestFilter.java
+++ b/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot2RequestFilter.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -23,6 +24,7 @@ import uk.gov.hmcts.reform.idam.client.IdamApi;
  */
 @Order(value = Ordered.HIGHEST_PRECEDENCE)
 @ConditionalOnClass({IdamApi.class, HttpServletRequest.class})
+@ConditionalOnExpression("#{T(org.springframework.boot.SpringBootVersion).getVersion().startsWith('2')}")
 @Component
 public class SpringBoot2RequestFilter extends OncePerRequestFilter {
 

--- a/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/URLRewriter.java
+++ b/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/URLRewriter.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.SpringBootVersion;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -29,9 +28,6 @@ public class URLRewriter extends OncePerRequestFilter {
     private final IdamApi idam;
 
     private final String name;
-
-    @Value("#{T(org.springframework.boot.SpringBootVersion).getVersion()}")
-    private String springBootVersion;
 
     @Autowired
     public URLRewriter(IdamApi idam,

--- a/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/URLRewriter.java
+++ b/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/URLRewriter.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootVersion;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -28,6 +29,9 @@ public class URLRewriter extends OncePerRequestFilter {
     private final IdamApi idam;
 
     private final String name;
+
+    @Value("#{T(org.springframework.boot.SpringBootVersion).getVersion()}")
+    private String springBootVersion;
 
     @Autowired
     public URLRewriter(IdamApi idam,

--- a/cftlib/lib/cftlib-agent/src/springBoot3/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot3RequestFilter.java
+++ b/cftlib/lib/cftlib-agent/src/springBoot3/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot3RequestFilter.java
@@ -32,11 +32,15 @@ public class SpringBoot3RequestFilter extends OncePerRequestFilter {
 
     private final String name;
 
+    private final boolean isCCD;
+
+
     @Autowired
     public SpringBoot3RequestFilter(IdamApi idam,
                                     @Value("${rse.lib.service_name:***CFT lib***}") String name) {
         this.idam = idam;
         this.name = name;
+        this.isCCD = name.toLowerCase().contains("ccd");
     }
 
     @Override
@@ -45,6 +49,10 @@ public class SpringBoot3RequestFilter extends OncePerRequestFilter {
         String name = Thread.currentThread().getName();
         try {
             Thread.currentThread().setName("*** " + this.name);
+            // Only emulate the CCD gateway for CCD services
+            request = isCCD ? new Rewriter(request) : request;
+            filterChain.doFilter(request, response);
+
             filterChain.doFilter(new Rewriter(request), response);
         } finally {
             Thread.currentThread().setName(name);

--- a/cftlib/lib/cftlib-agent/src/springBoot3/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot3RequestFilter.java
+++ b/cftlib/lib/cftlib-agent/src/springBoot3/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot3RequestFilter.java
@@ -1,0 +1,86 @@
+package uk.gov.hmcts.rse.ccd.lib;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import uk.gov.hmcts.reform.idam.client.IdamApi;
+
+import java.io.IOException;
+
+/**
+ * Names threads for easier debugging.
+ * Implements URL remappings handled by the CCD API Gateway.
+ */
+@Order(value = Ordered.HIGHEST_PRECEDENCE)
+@ConditionalOnClass({IdamApi.class, HttpServletRequest.class})
+@Component
+public class SpringBoot3RequestFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private final IdamApi idam;
+
+    private final String name;
+
+    @Autowired
+    public SpringBoot3RequestFilter(IdamApi idam,
+                                    @Value("${rse.lib.service_name:***CFT lib***}") String name) {
+        this.idam = idam;
+        this.name = name;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+        String name = Thread.currentThread().getName();
+        try {
+            Thread.currentThread().setName("*** " + this.name);
+            filterChain.doFilter(new Rewriter(request), response);
+        } finally {
+            Thread.currentThread().setName(name);
+        }
+    }
+
+    class Rewriter extends HttpServletRequestWrapper {
+        public Rewriter(HttpServletRequest request) {
+            super(request);
+        }
+
+        @Override
+        public String getServletPath() {
+            return process(super.getServletPath());
+        }
+
+        @Override
+        public String getRequestURI() {
+            return process(super.getRequestURI());
+        }
+
+        private String process(String url) {
+            // CCD Gateway strips this path.
+            if (url.startsWith("/data")) {
+                url = url.replaceFirst("/data", "");
+            }
+            // Gateway replaces placeholder userIDs.
+            if (url.contains("/:uid/")) {
+                url = substituteUserId(url);
+            }
+            return url;
+        }
+
+        private String substituteUserId(String url) {
+            var req = (HttpServletRequest) getRequest();
+            var auth = req.getHeader("Authorization");
+            var info = idam.retrieveUserInfo(auth);
+            return url.replace(":uid", info.getUid());
+        }
+    }
+}

--- a/cftlib/lib/cftlib-agent/src/springBoot3/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot3RequestFilter.java
+++ b/cftlib/lib/cftlib-agent/src/springBoot3/java/uk/gov/hmcts/rse/ccd/lib/SpringBoot3RequestFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,7 @@ import java.io.IOException;
  */
 @Order(value = Ordered.HIGHEST_PRECEDENCE)
 @ConditionalOnClass({IdamApi.class, HttpServletRequest.class})
+@ConditionalOnExpression("#{T(org.springframework.boot.SpringBootVersion).getVersion().startsWith('3')}")
 @Component
 public class SpringBoot3RequestFilter extends OncePerRequestFilter {
 

--- a/cftlib/lib/runtime/build.gradle
+++ b/cftlib/lib/runtime/build.gradle
@@ -24,9 +24,4 @@ processResources {
     from zipCompose
 }
 
-java {
-    withJavadocJar()
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-}
+

--- a/cftlib/test-project/build.gradle
+++ b/cftlib/test-project/build.gradle
@@ -24,6 +24,9 @@ def springBoot2 = testSpringBootVersion.startsWith("2")
 
 dependencies {
 
+    // Test this conflicting dependency doesn't break us on spring boot 3.
+    cftlibImplementation 'javax.servlet:javax.servlet-api:4.0.1'
+
     compileOnly 'org.projectlombok:lombok:1.18.28'
     annotationProcessor 'org.projectlombok:lombok:1.18.28'
 


### PR DESCRIPTION
### Change description ###

A request filter is provided that names threads (to help debugging) and emulates certain functions of the CCD API gateway.

This was not running on Spring Boot 3 projects due to the change in package name from javax to jakarta for many classes used by the request filter, which would break the Cftlib when eg. CCD upgrade to spring boot 3.


