### PR TITLE
fix simulator default internal docker url

### DIFF
--- a/cftlib/lib/runtime/compose/docker-compose.yml
+++ b/cftlib/lib/runtime/compose/docker-compose.yml
@@ -138,7 +138,6 @@ services:
     ports:
       - 5062:5062
     environment:
-      SIMULATOR_JWT_ISSUER: "${IDAM_SIMULATOR_BASE_URL:-http://localhost:5062}"
-      SIMULATOR_OPENID_BASE-URL: "${IDAM_SIMULATOR_BASE_URL:-http://localhost:5062}"
+      SIMULATOR_OPENID_BASE-URL: "${IDAM_SIMULATOR_BASE_URL:-http://rse-idam-simulator:5062}"
       SIMULATOR_OPENID_BASE-URL-OUTSIDE-NETWORK: "${IDAM_SIMULATOR_BASE_URL_OUTSIDE_NETWORK:-http://localhost:5062}"
       SERVER_PORT: 5062


### PR DESCRIPTION
This is the URL presented to internal docker clients in the oauth configuration and should therefore use the host's docker address and not localhost.