### PR TITLE
refactor service specific service args for AAC 

### DIFF
--- a/cftlib/init.gradle
+++ b/cftlib/init.gradle
@@ -27,6 +27,15 @@ def configurePublishing(p) {
             publications {
                 mavenJava(MavenPublication) {
                     from components.java
+                    // Remap these service entry point project to fit our naming convention
+                    if (project.name == "application")     {
+                       artifactId 'ccd-definition-store-api'
+                    } else if (project.name == "user-profile-api")     {
+                        artifactId 'ccd-user-profile-api'
+                    } else if (project.name == "rpa-dg-docassembly") {
+                        artifactId 'dg-docassembly-api'
+                    }
+
 
                     // We need to be able to reproduce the exact runtime classpath of each project.
                     // To do this we replace the pom dependencies with the complete runtime classpath.

--- a/cftlib/lib/cftlib-agent/build.gradle
+++ b/cftlib/lib/cftlib-agent/build.gradle
@@ -45,10 +45,10 @@ dependencies {
     implementation 'com.auth0:java-jwt:3.12.0'
 
     // Use the fat definition store code at compile time.
-    compileOnly 'com.github.hmcts.rse-cft-lib:application:DEV-SNAPSHOT'
+    compileOnly 'com.github.hmcts.rse-cft-lib:ccd-definition-store-api:DEV-SNAPSHOT'
 
     // Provide definition store for running tests
-    testImplementation 'com.github.hmcts.rse-cft-lib:application:DEV-SNAPSHOT'
+    testImplementation 'com.github.hmcts.rse-cft-lib:ccd-definition-store-api:DEV-SNAPSHOT'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.3'
 }
 
@@ -60,7 +60,7 @@ test {
 }
 
 // We depend on definition store code which must be published to maven local
-compileJava.dependsOn rootProject.task('publishccd-case-definition-store-api')
+compileJava.dependsOn (':publishccd-definition-store-api')
 
 
 // The cftlib brings in the cftlib Gradle plugin as a composite build.

--- a/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftLibPlugin.java
+++ b/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftLibPlugin.java
@@ -207,13 +207,9 @@ public class CftLibPlugin implements Plugin<Project> {
         for (var e : projects.entrySet()) {
             var file = cftlibBuildDir(project).file(e.getKey().id()).getAsFile();
             var args = Lists.newArrayList(
-                    "--rse.lib.service_name=" + e.getKey()
-            );
-            if (e.getKey().equals(Service.ccdDataStoreApi)) {
-                args.add("--idam.client.secret=${IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET:}");
-            } else if (e.getKey().equals(Service.aacManageCaseAssignment)) {
-                args.add("--idam.client.secret=${IDAM_OAUTH2_AAC_CLIENT_SECRET:}");
-            }
+                    "--rse.lib.service_name=" + e.getKey());
+
+            args.addAll(e.getKey().args);
             manifestTasks.add(
                     createCFTManifestTask(project, e.getKey().id(), e.getValue(), file, args.toArray(String[]::new)));
             manifests.add(file);

--- a/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftlibExec.java
+++ b/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftlibExec.java
@@ -75,7 +75,7 @@ public class CftlibExec extends JavaExec {
                 var cmd  = new ArrayList<>(List.of("az", "keyvault", "secret", "show", "-o", "tsv", "--query", "value",
                     // Pin to a specific version of the .env file for reproducible builds.
                     // This will need to be updated when the keyvault is modified.
-                    "--version", "f9b6c526b997434db36fed2de50faa64",
+                    "--version", "d40d4aa83a884fe7b6ea029b6007934f",
                     "--id", "https://rse-cft-lib.vault.azure.net/secrets/aat-env"));
                 // TODO: use the Azure java client library for cross platform secret retrieval
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {

--- a/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/Service.java
+++ b/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/Service.java
@@ -2,30 +2,28 @@ package uk.gov.hmcts.rse;
 
 import com.google.common.base.CaseFormat;
 
+import java.util.List;
+
 public enum Service {
     amRoleAssignmentService,
-    ccdDataStoreApi,
-    // 'application' is definition store entry module
-    ccdDefinitionStoreApi("application"),
-    ccdUserProfileApi("user-profile-api"),
-    aacManageCaseAssignment,
+    ccdDataStoreApi("--idam.client.secret=${IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET:}"),
+    ccdDefinitionStoreApi,
+    ccdUserProfileApi,
+    aacManageCaseAssignment("--idam.client.secret=${IDAM_OAUTH2_AAC_CLIENT_SECRET:}"),
     ccdCaseDocumentAmApi,
-    dgDocassemblyApi("rpa-dg-docassembly");
+    dgDocassemblyApi;
 
-    private final String id;
+    public final List<String> args;
 
     Service() {
-        this.id = null;
+        this.args = List.of();
     }
 
-    Service(String id) {
-        this.id = id;
+    Service(String... args) {
+        this.args = List.of(args);
     }
 
     public String id() {
-        if (id != null) {
-            return id;
-        }
         return CaseFormat.LOWER_CAMEL
                 .to(CaseFormat.LOWER_HYPHEN, toString())
                 .replace("_", "-");


### PR DESCRIPTION
### Change description ###

Simplify the addition of new service specific arg overrides and align all maven project names upon a single naming convention.

Bumps AAT keyvault containing new AAC creds.
