### PR TITLE
Fix IdamAugmenter on spring boot 3 (+ tests)

### DIFF
--- a/cftlib/lib/cftlib-agent/build.gradle
+++ b/cftlib/lib/cftlib-agent/build.gradle
@@ -62,6 +62,10 @@ test {
 // We depend on definition store code which must be published to maven local
 compileJava.dependsOn (':publishccd-definition-store-api')
 
+// https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention
+tasks.withType(JavaCompile).configureEach {
+//    options.compilerArgs.add("-parameters")
+}
 
 // The cftlib brings in the cftlib Gradle plugin as a composite build.
 // This means Gradle attempts to resolve dependency configurations at configuration time instead of execution time,

--- a/cftlib/lib/cftlib-agent/build.gradle
+++ b/cftlib/lib/cftlib-agent/build.gradle
@@ -64,7 +64,7 @@ compileJava.dependsOn (':publishccd-definition-store-api')
 
 // https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention
 tasks.withType(JavaCompile).configureEach {
-//    options.compilerArgs.add("-parameters")
+    options.compilerArgs.add("-parameters")
 }
 
 // The cftlib brings in the cftlib Gradle plugin as a composite build.

--- a/cftlib/test-project/build.gradle
+++ b/cftlib/test-project/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'com.github.hmcts', name: 'idam-java-client', version: (springBoot2 ? '2.1.1' : '3.0.3')
+    // Presence of JWT related deps will activate the IdamAugmenter
+    implementation 'com.auth0:java-jwt:4.4.0'
+    implementation group: 'org.springframework.security', name: 'spring-security-oauth2-jose', version: '6.2.3'
+
     if (springBoot2) {
       // v2 idam java client needs this dependency but appears not to declare it correctly.
       implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.3'
@@ -53,7 +57,6 @@ dependencies {
 
     cftlibTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '3.0.2'
     cftlibTestImplementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.14'
-    cftlibTestImplementation 'com.auth0:java-jwt:4.4.0'
     cftlibTestImplementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     cftlibTestImplementation 'org.awaitility:awaitility:4.2.0'
 }


### PR DESCRIPTION
### Change description ###

Spring boot 3.2 requires code to be compiled with the -parameters switch in order for aspectj to correctly identify parameter names.

https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention

We didn't catch this in our spring boot tests because the IdamAugmenter wasn't running in the test project due to a missing jar, now fixed.
