### PR TITLE
expose WA feature flags thru docker

### DIFF
--- a/cftlib/lib/runtime/compose/docker-compose.yml
+++ b/cftlib/lib/runtime/compose/docker-compose.yml
@@ -68,6 +68,8 @@ services:
       SERVICES_WORK_ALLOCATION_TASK_API: "http://wa-task-management-api-aat.service.core-compute-aat.internal"
       HEALTH_WORK_ALLOCATION_TASK_API: "http://wa-task-management-api-aat.service.core-compute-aat.internal/health"
       SERVICES_LOCATION_REF_API_URL: ${SERVICES_LOCATION_REF_API_URL}
+      FEATURE_WORKALLOCATION_ENABLED: ${FEATURE_WORKALLOCATION_ENABLED:-false}
+      WA_SUPPORTED_JURISDICTIONS: "${WA_SUPPORTED_JURISDICTIONS:-IA,CIVIL,PRIVATELAW,PUBLICLAW,EMPLOYMENT,ST_CIC}"
     ports:
       - ${XUI_PORT:-3000}:3000
     extra_hosts:


### PR DESCRIPTION
### Change description ###
- allow teams to enable/disable work allocation by exposing feature flags through docker

