### PR TITLE
SSCSCI-1854 Add Docker Long Pull in CFTLib

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ Services run on the following default ports:
 
 For a clean boot define the RSE_LIB_CLEAN_BOOT environment variable, which will force recreate all docker containers upon boot.
 
+### Long Docker Pull Timeout boot
+
+For a long docker pull timeout boot define the RSE_LIB_DOCKER_LONG_TIMEOUT environment variable, which will set the docker timeout to 90 minutes instead of 10. This option is useful when using cftlib for the first time to be able to download the biggest docker images.
+
 ### Live reload
 
 [Spring boot's devtools](https://docs.spring.io/spring-boot/docs/current/reference/html/using.html#using.devtools) can be used to fast-reload your application whilst leaving other CFT services running, significantly 

--- a/cftlib/lib/runtime/src/main/java/uk/gov/hmcts/rse/ccd/lib/ComposeRunner.java
+++ b/cftlib/lib/runtime/src/main/java/uk/gov/hmcts/rse/ccd/lib/ComposeRunner.java
@@ -66,13 +66,18 @@ public class ComposeRunner {
             args.add("--renew-anon-volumes");
         }
 
+        long dockerTimeout =10;`
+        if (null != System.getenv("RSE_LIB_DOCKER_LONG_TIMEOUT")) {
+            dockerTimeout = 90;
+        }
+
         new ProcessExecutor().command(args)
             .environment(getEnvironmentVars())
             .redirectOutput(System.out)
             .redirectError(System.err)
             .directory(dir.toFile())
             .exitValueNormal()
-            .timeout(10, TimeUnit.MINUTES)
+            .timeout(dockerTimeout, TimeUnit.MINUTES)
             .execute();
 
     }


### PR DESCRIPTION
Add Docker Long Pull in CFTLib
 https://tools.hmcts.net/jira/browse/SSCSCI-1854

Issue:
The first time a CFTLib run on a computer with the command ./gradlew bootWithCcd, docker will pull all the dependencies and this can take up to 1h. But currently the timeout is 10min, so the command needs to be several times in order to have all dependencies pull.
Fix:
Add a Docker Long Pull Option in CFTLib to increase the timeout to 90min


