### PR TITLE
More azure artifacts fixes

### DIFF
--- a/cftlib/build.gradle
+++ b/cftlib/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'idea'
 apply plugin: 'base'
 
-tasks.register('publish')
+tasks.register('publishToMavenLocal')
 tasks.register('publishToAzureArtifacts')
 
 // Create Gradle tasks that build and publish the CFT submodule projects to maven local.
@@ -18,7 +18,7 @@ project.file('../projects').listFiles().each { dir ->
         args '--no-daemon','-i', '-s', '-I', project.file('init.gradle').path, 'publishToMavenLocal'
         workingDir dir
     }
-    publish.dependsOn t
+    publishToMavenLocal.dependsOn t
 
     def p = task "publish${dir.name}ToAzureArtifacts"(type: Exec) {
         executable './gradlew'
@@ -26,10 +26,9 @@ project.file('../projects').listFiles().each { dir ->
         workingDir dir
     }
     publishToAzureArtifacts.dependsOn p
-
 }
 
-publish.dependsOn gradle.includedBuild('rse-cft-lib-plugin').task(':publishToMavenLocal')
+publishToMavenLocal.dependsOn gradle.includedBuild('rse-cft-lib-plugin').task(':publishToMavenLocal')
 publishToAzureArtifacts.dependsOn gradle.includedBuild('rse-cft-lib-plugin').task(':publishAllPublicationsToAzureArtifactsRepository')
 
 tasks.check.dependsOn gradle.includedBuild('rse-cft-lib-plugin').task(':check')

--- a/cftlib/lib/build.gradle
+++ b/cftlib/lib/build.gradle
@@ -1,17 +1,19 @@
 
 plugins {
     id 'uk.gov.hmcts.java' version '0.12.24' apply false
+    id 'io.freefair.lombok' version '8.13.1' apply false
 }
 
 subprojects {
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
     apply plugin: 'uk.gov.hmcts.java'
+    apply plugin: 'io.freefair.lombok'
 
     repositories {
         mavenCentral()
         maven {
-            url 'https://jitpack.io'
+            url = uri('https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1')
         }
     }
 
@@ -29,17 +31,20 @@ subprojects {
                 from components.java
             }
         }
+        repositories {
+            maven {
+                name = "AzureArtifacts"
+                url = uri("https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1")
+                credentials {
+                    username = System.getenv("AZURE_DEVOPS_ARTIFACT_USERNAME")
+                    password = System.getenv("AZURE_DEVOPS_ARTIFACT_TOKEN")
+                }
+            }
+        }
     }
 
-    dependencies {
-        compileOnly 'org.projectlombok:lombok:1.18.22'
-        annotationProcessor 'org.projectlombok:lombok:1.18.22'
-
-        testCompileOnly 'org.projectlombok:lombok:1.18.22'
-        testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'
-    }
-
-    rootProject.tasks.publish.dependsOn(project.tasks.publishToMavenLocal)
+    rootProject.tasks.publishToMavenLocal.dependsOn(project.tasks.publishToMavenLocal)
+    rootProject.tasks.publishToAzureArtifacts.dependsOn(project.tasks.publishAllPublicationsToAzureArtifactsRepository)
 
     java {
         withJavadocJar()

--- a/cftlib/lib/cftlib-agent/build.gradle
+++ b/cftlib/lib/cftlib-agent/build.gradle
@@ -1,6 +1,15 @@
 
 repositories {
     mavenLocal()
+    maven {
+        // TODO: Remove once CCD no longer uses jitpack
+        url 'https://jitpack.io'
+        content {
+            includeVersion 'com.github.hmcts.java-logging', 'logging', '6.0.1'
+            includeVersion 'com.github.hmcts', 'service-auth-provider-java-client', '4.0.3'
+            includeVersion 'com.github.hmcts', 'idam-java-client', '2.0.1'
+        }
+    }
 }
 
 // Used to compile classes for Spring Boot 3 that cannot be compiled with a Spring Boot 2 classpath.
@@ -23,7 +32,7 @@ dependencies {
     compileOnly 'org.aspectj:aspectjweaver:1.9.7'
     compileOnly 'org.springframework.boot:spring-boot:2.4.12'
     compileOnly 'org.springframework.boot:spring-boot-autoconfigure:2.4.12'
-    compileOnly 'com.github.hmcts:service-auth-provider-java-client:4.0.2'
+    compileOnly 'com.github.hmcts:service-auth-provider-java-client:5.3.2'
     compileOnly 'org.springframework.security:spring-security-oauth2-jose:5.4.9'
 
     springBoot3CompileOnly 'org.springframework.boot:spring-boot:3.2.0'
@@ -31,21 +40,21 @@ dependencies {
     springBoot3CompileOnly group: 'org.springframework', name: 'spring-web', version: '6.1.3'
     springBoot3CompileOnly 'jakarta.servlet:jakarta.servlet-api:6.0.0'
 
-    springBoot3CompileOnly('com.github.hmcts:idam-java-client:2.0.1') {
+    springBoot3CompileOnly('com.github.hmcts:idam-java-client:3.0.4') {
         transitive = false
     }
 
-    compileOnly('com.github.hmcts:idam-java-client:2.0.1') {
+    compileOnly('com.github.hmcts:idam-java-client:2.1.2') {
         transitive = false
     }
-    compileOnly('com.github.hmcts:auth-checker-lib:2.1.4') {
+    compileOnly('com.github.hmcts:auth-checker-lib:3.1.1') {
         transitive = false
     }
     // This is needed at runtime to decode JWTs
     implementation 'com.auth0:java-jwt:3.12.0'
 
     // Use the fat definition store code at compile time.
-    compileOnly 'com.github.hmcts.rse-cft-lib:ccd-definition-store-api:DEV-SNAPSHOT'
+    compileOnly ('com.github.hmcts.rse-cft-lib:ccd-definition-store-api:DEV-SNAPSHOT')
 
     // Provide definition store for running tests
     testImplementation 'com.github.hmcts.rse-cft-lib:ccd-definition-store-api:DEV-SNAPSHOT'

--- a/cftlib/rse-cft-lib-plugin/build.gradle
+++ b/cftlib/rse-cft-lib-plugin/build.gradle
@@ -10,7 +10,6 @@ plugins {
     // Apply the Java Gradle plugin development plugin to add support for developing Gradle plugins
     id 'java-gradle-plugin'
     id 'maven-publish'
-    id 'com.gradle.plugin-publish' version '1.2.0'
     id 'uk.gov.hmcts.java' version '0.12.43'
 }
 
@@ -19,7 +18,6 @@ version System.getenv('RELEASE_VERSION') ?: 'DEV-SNAPSHOT'
 
 repositories {
   mavenCentral()
-  maven { url 'https://jitpack.io' }
   mavenLocal()
 }
 

--- a/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftLibPlugin.java
+++ b/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftLibPlugin.java
@@ -82,7 +82,23 @@ public class CftLibPlugin implements Plugin<Project> {
 
             // Keep jitpack as a fallback for now.
             // TODO: remove this once common components have all switched to azure artifacts
-            p.getRepositories().maven(m -> m.setUrl("https://jitpack.io"));
+            p.getRepositories().maven(m -> {
+                m.setUrl("https://jitpack.io");
+                m.content(c -> {
+                    c.includeVersion("com.github.hmcts", "idam-java-client", "2.1.2");
+                    c.includeVersion("com.github.hmcts", "idam-java-client", "2.1.1");
+                    c.includeVersion("com.github.hmcts", "idam-java-client", "2.0.1");
+                    c.includeVersion("com.github.hmcts", "idam-java-client", "1.5.5");
+                    c.includeVersion("com.github.hmcts", "ccd-case-document-am-client", "1.7.1");
+                    c.includeVersion("com.github.hmcts", "auth-checker-lib", "2.1.5");
+                    c.includeVersion("com.github.hmcts.java-logging", "logging", "6.1.8");
+                    c.includeVersion("com.github.hmcts.java-logging", "logging", "6.0.1");
+                    c.includeVersion("com.github.hmcts.java-logging", "logging-appinsights", "6.0.1");
+                    c.includeVersion("com.github.hmcts", "service-auth-provider-java-client", "4.0.3");
+                    c.includeVersion("com.github.hmcts", "service-auth-provider-java-client", "4.0.2");
+                    c.includeVersion("com.github.hmcts", "service-auth-provider-java-client", "3.1.4");
+                });
+            });
         });
     }
 

--- a/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftLibPlugin.java
+++ b/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftLibPlugin.java
@@ -75,7 +75,6 @@ public class CftLibPlugin implements Plugin<Project> {
     private void registerDependencyRepositories(Project project) {
         // We do this after evaluation to ensure these repositories are registered after those in the build script.
         project.afterEvaluate(p -> {
-            p.getRepositories().mavenCentral();
             String azureUrl = "https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1";
             boolean azureRepoExists = project.getRepositories().stream()
                     .anyMatch(repo -> repo instanceof MavenArtifactRepository

--- a/cftlib/test-project/build.gradle
+++ b/cftlib/test-project/build.gradle
@@ -5,12 +5,13 @@ import uk.gov.hmcts.rse.ManifestTask
 plugins {
     id 'jacoco'
     id 'org.springframework.boot' version "${testSpringBootVersion}"
-    id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
     id 'com.github.hmcts.rse-cft-lib'
     id 'uk.gov.hmcts.java' version '0.12.43'
     id 'io.freefair.lombok' version '8.13.1'
 }
+
+apply plugin: 'io.spring.dependency-management'
 
 java {
     toolchain {
@@ -39,16 +40,13 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation group: 'org.springframework.security', name: 'spring-security-oauth2-jose', version: '6.2.3'
 
-    if (springBoot2) {
-      // v2 idam java client needs this dependency but appears not to declare it correctly.
-      implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.3'
-    }
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.3'
     cftlibTestImplementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
 
     cftlibTestImplementation 'org.springframework.boot:spring-boot-starter-test'
     cftlibTestImplementation 'org.springframework.security:spring-security-test'
 
-    cftlibTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '3.0.2'
+    cftlibTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     cftlibTestImplementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.14'
     cftlibTestImplementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     cftlibTestImplementation 'org.awaitility:awaitility:4.2.0'

--- a/cftlib/test-project/build.gradle
+++ b/cftlib/test-project/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/cftlib/test-project/build.gradle
+++ b/cftlib/test-project/build.gradle
@@ -9,11 +9,12 @@ plugins {
     id 'java'
     id 'com.github.hmcts.rse-cft-lib'
     id 'uk.gov.hmcts.java' version '0.12.43'
+    id 'io.freefair.lombok' version '8.13.1'
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 
@@ -28,21 +29,11 @@ dependencies {
     // Test this conflicting dependency doesn't break us on spring boot 3.
     cftlibImplementation 'javax.servlet:javax.servlet-api:4.0.1'
 
-    compileOnly 'org.projectlombok:lombok:1.18.28'
-    annotationProcessor 'org.projectlombok:lombok:1.18.28'
-
     // Enable live reload of just our application
     cftlibImplementation 'org.springframework.boot:spring-boot-devtools'
 
-    cftlibCompileOnly 'org.projectlombok:lombok:1.18.28'
-    cftlibAnnotationProcessor 'org.projectlombok:lombok:1.18.28'
-
-    cftlibTestCompileOnly 'org.projectlombok:lombok:1.18.28'
-    cftlibTestAnnotationProcessor 'org.projectlombok:lombok:1.18.28'
-
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
-    implementation group: 'com.github.hmcts', name: 'idam-java-client', version: (springBoot2 ? '2.1.1' : '3.0.3')
     // Presence of JWT related deps will activate the IdamAugmenter
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation group: 'org.springframework.security', name: 'spring-security-oauth2-jose', version: '6.2.3'
@@ -85,25 +76,25 @@ test {
 
 tasks.each {
     if (it.name.contains("writeManifest")) {
-        it.dependsOn(rootProject.tasks.publish)
+        it.dependsOn(rootProject.tasks.publishToMavenLocal)
     }
 }
 tasks.test.dependsOn(bootWithCCD)
-bootWithCCD.dependsOn(rootProject.tasks.publish)
+bootWithCCD.dependsOn(rootProject.tasks.publishToMavenLocal)
 bootWithCCD.mustRunAfter cftlibTest
 
 tasks.test.dependsOn(cftlibTest)
-cftlibTest.dependsOn(rootProject.tasks.publish)
-cftlibTestClasses.dependsOn(rootProject.tasks.publish)
+cftlibTest.dependsOn(rootProject.tasks.publishToMavenLocal)
+cftlibTestClasses.dependsOn(rootProject.tasks.publishToMavenLocal)
 
 task publishSecrets(type: Exec) {
     commandLine 'az', 'keyvault', 'secret', 'set', "--vault-name", "rse-cft-lib", "--name", "aat-env", "--file", layout.buildDirectory.file('cftlib/.aat-env').get().asFile.path
 }
 
 // Ensure we publish all required dependencies to maven local
-tasks.compileCftlibJava.dependsOn rootProject.publish
+tasks.compileCftlibJava.dependsOn rootProject.tasks.publishToMavenLocal
 tasks.withType(ManifestTask).each {
-    it.dependsOn rootProject.publish
+    it.dependsOn rootProject.tasks.publishToMavenLocal
 }
 configurations.each {
     it.resolutionStrategy.useGlobalDependencySubstitutionRules = false

--- a/cftlib/test-project/build.gradle
+++ b/cftlib/test-project/build.gradle
@@ -20,6 +20,7 @@ java {
 
 repositories {
     mavenLocal()
+    mavenCentral()
 }
 
 def springBoot2 = testSpringBootVersion.startsWith("2")

--- a/cftlib/test-project/gradle.properties
+++ b/cftlib/test-project/gradle.properties
@@ -2,4 +2,4 @@
 buildDir=../build
 # The version of spring boot to test in the consumer test project.
 # Provide a default value that can be overriden in github actions to test multiple spring boot versions
-testSpringBootVersion=2.6.10
+testSpringBootVersion=2.7.18


### PR DESCRIPTION
Use an explicit allowlist for the legacy fallback jitpack dependency repository that we create, until we can remove it entirely.




