### PR TITLE
Hdpi 1252 use azure sdk for secrets

### DIFF
--- a/cftlib/rse-cft-lib-plugin/build.gradle
+++ b/cftlib/rse-cft-lib-plugin/build.gradle
@@ -22,16 +22,19 @@ repositories {
 }
 
 dependencies {
-    // Use JUnit test framework for unit tests
-    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.36'
-    compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.36'
-    implementation 'com.google.guava:guava:32.0.1-jre'
+    implementation platform('com.azure:azure-sdk-bom:1.2.36')
+    implementation group: 'com.azure', name: 'azure-security-keyvault-secrets'
+    implementation group: 'com.azure', name: 'azure-identity'
+
+    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.38'
+    compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.38'
+    implementation 'com.google.guava:guava:33.4.8-jre'
     implementation "com.github.hmcts.rse-cft-lib:ccd-gradle-plugin:${version}"
 
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation group: 'commons-io', name: 'commons-io', version: '2.13.0'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation group: 'commons-io', name: 'commons-io', version: '2.19.0'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.27.3'
 }
 
 gradlePlugin {

--- a/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftlibExec.java
+++ b/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftlibExec.java
@@ -74,7 +74,11 @@ public class CftlibExec extends JavaExec {
             return;
         }
 
-        var env = CftLibPlugin.cftlibBuildDir(getProject()).file(".aat-env").getAsFile();
+        // Pin to a specific version of the .env file for reproducible builds.
+        // This will need to be updated when the keyvault is modified.
+        String secretVersion = "3aa0d793f49049f682aac07c490cc166";
+
+        var env = CftLibPlugin.cftlibBuildDir(getProject()).file(".aat-env-" + secretVersion).getAsFile();
         if (!env.exists()) {
             try (var os = new OutputStreamWriter(new FileOutputStream(getProject().file(env)))) {
                 SecretClient secretClient = new SecretClientBuilder()
@@ -82,9 +86,6 @@ public class CftlibExec extends JavaExec {
                         .vaultUrl("https://rse-cft-lib.vault.azure.net")
                         .buildClient();
 
-                // Pin to a specific version of the .env file for reproducible builds.
-                // This will need to be updated when the keyvault is modified.
-                String secretVersion = "3aa0d793f49049f682aac07c490cc166";
                 KeyVaultSecret secret = secretClient.getSecret("aat-env", secretVersion);
 
                 os.write(secret.getValue());

--- a/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftlibExec.java
+++ b/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftlibExec.java
@@ -1,15 +1,16 @@
 package uk.gov.hmcts.rse;
 
-import java.io.FileOutputStream;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.azure.identity.AzureCliCredentialBuilder;
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
 import lombok.SneakyThrows;
-import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainService;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class CftlibExec extends JavaExec {
     public AuthMode authMode = AuthMode.AAT;
@@ -71,34 +72,27 @@ public class CftlibExec extends JavaExec {
             return;
         }
 
-        var env = CftLibPlugin.cftlibBuildDir(getProject()).file(".aat-env").getAsFile();
-        if (!env.exists()) {
-            try (var os = new FileOutputStream(getProject().file(env))) {
-                var cmd  = new ArrayList<>(List.of("az", "keyvault", "secret", "show", "-o", "tsv", "--query", "value",
-                    // Pin to a specific version of the .env file for reproducible builds.
-                    // This will need to be updated when the keyvault is modified.
-                    "--version", "3aa0d793f49049f682aac07c490cc166",
-                    "--id", "https://rse-cft-lib.vault.azure.net/secrets/aat-env"));
-                // TODO: use the Azure java client library for cross platform secret retrieval
-                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    cmd.addAll(0, List.of("cmd", "/c"));
-                }
-                getProject().exec(x -> {
-                    x.commandLine(cmd);
-                    x.setStandardOutput(os);
-                });
-            }
-        }
+        SecretClient secretClient = new SecretClientBuilder()
+                .credential(new AzureCliCredentialBuilder().build())
+                .vaultUrl("https://rse-cft-lib.vault.azure.net")
+                .buildClient();
 
-        var lines = Files.readAllLines(env.toPath());
-        for (String line : lines) {
-            var index = line.indexOf("=");
-            if (index != -1) {
-                var key = line.substring(0, index);
-                var value = line.substring(index + 1);
-                environment(key, value);
-            }
-        }
+        // Pin to a specific version of the .env file for reproducible builds.
+        // This will need to be updated when the keyvault is modified.
+        String secretVersion = "3aa0d793f49049f682aac07c490cc166";
+        KeyVaultSecret secret = secretClient.getSecret("aat-env", secretVersion);
+
+        String[] lines = secret.getValue().split("\n");
+        Arrays.stream(lines)
+                .forEach(line -> {
+                    var index = line.indexOf("=");
+                    if (index != -1) {
+                        var key = line.substring(0, index);
+                        var value = line.substring(index + 1);
+                        environment(key, value);
+                    }
+                });
+
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Change description ###

Same change as https://github.com/hmcts/rse-cft-lib/pull/1953 but for the `decentralised-v2` branch

Use the Azure KeyVault SDK to get AAT settings/secrets rather than calling the az command line directly. This seems to be more reliable when running in the IDE in my local environment and also makes the code cross-platform as suggested by the existing TODO comment.

Also updating some dependency versions.

