### PR TITLE
Add definition snapshot dumping

### DIFF
--- a/cftlib/lib/bootstrapper/src/main/java/uk/gov/hmcts/rse/ccd/lib/ControlPlane.java
+++ b/cftlib/lib/bootstrapper/src/main/java/uk/gov/hmcts/rse/ccd/lib/ControlPlane.java
@@ -69,14 +69,15 @@ public class ControlPlane {
     }
 
     // Signal that an application has booted.
-    public static void appReady() {
+    public static void appReady(String name) {
         APPS_READY.countDown();
+        var c = APPS_READY.getCount();
+        System.out.println("**** Cftlib application " + name + " is ready **** " + c + " remaining");
     }
 
     @SneakyThrows
     public static CFTLib getApi() {
         waitForBoot();
-        API_READY.await();
         return api;
     }
 

--- a/cftlib/lib/bootstrapper/src/main/java/uk/gov/hmcts/rse/ccd/lib/api/CFTLib.java
+++ b/cftlib/lib/bootstrapper/src/main/java/uk/gov/hmcts/rse/ccd/lib/api/CFTLib.java
@@ -58,4 +58,10 @@ public interface CFTLib {
      * Private method invoked automatically to create CCD's global search elasticsearch index.
      */
     void createGlobalSearchIndex();
+
+    String generateDummyS2SToken(String serviceName);
+
+    String buildJwt();
+
+    void dumpDefinitionSnapshots();
 }

--- a/cftlib/lib/runtime/src/main/java/uk/gov/hmcts/rse/ccd/lib/ESIndexer.java
+++ b/cftlib/lib/runtime/src/main/java/uk/gov/hmcts/rse/ccd/lib/ESIndexer.java
@@ -10,6 +10,7 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.sql.Connection;
@@ -19,6 +20,7 @@ import java.util.Set;
 // Simple indexer replicating logstash functionality
 // but saving up to ~1GB of RAM.
 @Component
+@ConditionalOnProperty(value = "ccd.sdk.decentralised", havingValue = "false", matchIfMissing = true)
 public class ESIndexer {
 
     @SneakyThrows


### PR DESCRIPTION
This provides a build time facility to capture definition snapshots from definition store as static json files.

This is an as yet undocumented emerging feature that will be used by special tribunals in their decentralisation migration.




