### PR TITLE
HDPI-1252: Cache AAT secrets locally

### DIFF
--- a/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftlibExec.java
+++ b/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftlibExec.java
@@ -9,7 +9,9 @@ import org.gradle.api.tasks.JavaExec;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 
-import java.util.Arrays;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
 import java.util.List;
 
 public class CftlibExec extends JavaExec {
@@ -70,26 +72,33 @@ public class CftlibExec extends JavaExec {
             return;
         }
 
-        SecretClient secretClient = new SecretClientBuilder()
-                .credential(new AzureCliCredentialBuilder().build())
-                .vaultUrl("https://rse-cft-lib.vault.azure.net")
-                .buildClient();
-
         // Pin to a specific version of the .env file for reproducible builds.
         // This will need to be updated when the keyvault is modified.
         String secretVersion = "3aa0d793f49049f682aac07c490cc166";
-        KeyVaultSecret secret = secretClient.getSecret("aat-env", secretVersion);
 
-        String[] lines = secret.getValue().split("\n");
-        Arrays.stream(lines)
-                .forEach(line -> {
-                    var index = line.indexOf("=");
-                    if (index != -1) {
-                        var key = line.substring(0, index);
-                        var value = line.substring(index + 1);
-                        environment(key, value);
-                    }
-                });
+        var env = CftLibPlugin.cftlibBuildDir(getProject()).file(".aat-env-" + secretVersion).getAsFile();
+        if (!env.exists()) {
+            try (var os = new OutputStreamWriter(new FileOutputStream(getProject().file(env)))) {
+                SecretClient secretClient = new SecretClientBuilder()
+                        .credential(new AzureCliCredentialBuilder().build())
+                        .vaultUrl("https://rse-cft-lib.vault.azure.net")
+                        .buildClient();
+
+                KeyVaultSecret secret = secretClient.getSecret("aat-env", secretVersion);
+
+                os.write(secret.getValue());
+            }
+        }
+
+        var lines = Files.readAllLines(env.toPath());
+        for (String line : lines) {
+            var index = line.indexOf("=");
+            if (index != -1) {
+                var key = line.substring(0, index);
+                var value = line.substring(index + 1);
+                environment(key, value);
+            }
+        }
 
     }
 


### PR DESCRIPTION
### Change description ###

Fixing a missed cherry pick when the changes from https://github.com/hmcts/rse-cft-lib/pull/1953 were applied for the main branch (#2016)

That change was to use the Azure KeyVault SDK to get AAT settings/secrets rather than calling the az command line directly, however, the local caching of the secrets from the keyvault was missed.

I've made my local copy of the `decentralised-v2` branch have the same `CftlibExec` class as this PR, (apart from a couple of unrelated environment variables that are also being set in that branch), and tested locally that the file is written as expected. I don't have a non-decentralised service to test it against


