### PR TITLE
Use definition store for global search index setup

### DIFF
--- a/cftlib/lib/runtime/build.gradle
+++ b/cftlib/lib/runtime/build.gradle
@@ -32,10 +32,6 @@ task zipCompose(type: Zip) {
 
 processResources {
     from zipCompose
-    from(rootProject.file('../projects/ccd-definition-store-api/elastic-search-support/src/main/resources')) {
-        include 'globalSearchCasesIndexSettings.json'
-        include 'globalSearchCasesMapping.json'
-    }
 }
 
 test {

--- a/cftlib/lib/runtime/src/main/java/uk/gov/hmcts/rse/ccd/lib/CFTLibApiImpl.java
+++ b/cftlib/lib/runtime/src/main/java/uk/gov/hmcts/rse/ccd/lib/CFTLibApiImpl.java
@@ -252,47 +252,17 @@ public class CFTLibApiImpl implements CFTLib {
     @SneakyThrows
     @Override
     public void createGlobalSearchIndex() {
-        var client = HttpClient.newHttpClient();
-        var aliasCheck = HttpRequest.newBuilder()
-            .uri(URI.create("http://localhost:9200/_alias/global_search"))
-            .method("HEAD", HttpRequest.BodyPublishers.noBody())
-            .build();
-        var aliasResponse = client.send(aliasCheck, HttpResponse.BodyHandlers.discarding());
-        if (aliasResponse.statusCode() == 200) {
-            return;
+        HttpPost create = new HttpPost("http://localhost:4451/elastic-support/global-search/index");
+        create.addHeader("Authorization", "Bearer " + buildJwt());
+        create.addHeader("ServiceAuthorization", generateDummyS2SToken("ccd_gw"));
+        var response = HttpClients.createDefault().execute(create);
+
+        if (!String.valueOf(response.getStatusLine().getStatusCode()).startsWith("2")) {
+            var body = EntityUtils.toString(response.getEntity());
+            throw new RuntimeException(
+                    "Failed to create GlobalSearch ElasticSearch index: HTTP "
+                            + response.getStatusLine().getStatusCode() + " " + body);
         }
-        if (aliasResponse.statusCode() != 404) {
-            throw new RuntimeException("Failed to check GlobalSearch ElasticSearch alias: HTTP "
-                + aliasResponse.statusCode());
-        }
-
-        var settings = new Gson().fromJson(resource("globalSearchCasesIndexSettings.json"), Map.class);
-        settings.put("index.number_of_shards", 1);
-        settings.put("index.number_of_replicas", 0);
-        settings.put("index.mapping.total_fields.limit", 10000);
-
-        var mapping = new Gson().fromJson(resource("globalSearchCasesMapping.json"), Map.class);
-        var body = new Gson().toJson(Map.of(
-            "aliases", Map.of("global_search", Map.of()),
-            "settings", settings,
-            "mappings", mapping
-        ));
-        var create = HttpRequest.newBuilder()
-            .uri(URI.create("http://localhost:9200/global_search-000001"))
-            .header("Content-Type", "application/json")
-            .PUT(HttpRequest.BodyPublishers.ofString(body))
-            .build();
-        var response = client.send(create, HttpResponse.BodyHandlers.ofString());
-
-        if (!String.valueOf(response.statusCode()).startsWith("2")) {
-            throw new RuntimeException("Failed to create GlobalSearch ElasticSearch index: HTTP "
-                + response.statusCode() + " " + response.body());
-        }
-    }
-
-    @SneakyThrows
-    private String resource(String name) {
-        return Resources.toString(Resources.getResource(name), StandardCharsets.UTF_8);
     }
 
     /**

--- a/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftLibPlugin.java
+++ b/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftLibPlugin.java
@@ -359,7 +359,7 @@ public class CftLibPlugin implements Plugin<Project> {
         var dependencies = Lists.newArrayList(libDependencies(project, dependency, "cftlib-agent"));
         if (service == Service.ccdDefinitionStoreApi) {
             dependencies.add(project.getDependencies()
-                .create("org.elasticsearch.client:elasticsearch-rest-high-level-client:7.11.2"));
+                .create("co.elastic.clients:elasticsearch-java:9.1.2"));
         }
         return dependencies.toArray(Dependency[]::new);
     }


### PR DESCRIPTION
CFTLib was creating the Global Search Elasticsearch index itself using copies of CCD definition-store JSON resources. The published runtime jar then failed when those resources were missing.

This changes CFTLib to call CCD definition-store's existing global search index endpoint instead, so the index setup stays owned by CCD. It also removes the runtime resource copy and updates the definition-store manifest dependency to include the Elasticsearch Java client needed by the current CCD definition-store code.