### PR TITLE
Update Key Vault secret version for AAT environment

### DIFF
--- a/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftlibExec.java
+++ b/cftlib/rse-cft-lib-plugin/src/main/java/uk/gov/hmcts/rse/CftlibExec.java
@@ -74,7 +74,7 @@ public class CftlibExec extends JavaExec {
 
         // Pin to a specific version of the .env file for reproducible builds.
         // This will need to be updated when the keyvault is modified.
-        String version = "1657438f080948a29a330542724d5a13";
+        String version = "9965bd45e4b9480fbcef609a8a0151f3";
 
         var env = CftLibPlugin.cftlibBuildDir(getProject()).file(".aat-env-" + version).getAsFile();
         if (!env.exists()) {


### PR DESCRIPTION
Updates the pinned AAT environment secret to the latest enabled version in the rse-cft-lib Key Vault.

The previous version stored the environment assignments on one line. The replacement stores each assignment on its own line so CFTLib can read and apply them correctly.

This supersedes #2554 using a branch in hmcts/rse-cft-lib so the Azure OIDC build can run with the required permissions.