### PR TITLE
Support direct JSON definition imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,23 @@ public class CFTLibConfig implements CFTLibConfigurer {
 
 Note that your CFTLibConfigurer implementation must be in the cftlib sourceset.
 
+CCD definitions can also be imported directly from the JSON source used by the CCD definition processor:
+
+```java
+lib.importJsonDefinition(
+    new File("ccd-definitions/jurisdictions/england-wales/json")
+);
+```
+
+This supports split sheet directories, the processor's `AccessControl` and `UserRoles` shorthand, and
+environment substitutions beginning with `CCD_DEF`, `ET_COS`, or `ET_ENV`. `*-prod.json` fragments are
+excluded by default for the local cftlib environment. Set `CCD_DEF_EXCLUDED_FILENAME_PATTERNS` to a
+comma-separated list of glob patterns to override this.
+
+If the JSON directory has a sibling `data/ccd-template.xlsx`, its sheet names and columns are used in the
+same way as the JSON-to-XLSX processor. This supports definitions whose physical template sheet name differs
+from its CCD sheet name and ensures unknown JSON properties are ignored consistently.
+
 ### 3. Launch your application + CCD
 ```gradle
 ./gradlew bootWithCCD

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ environment substitutions beginning with `CCD_DEF`, `ET_COS`, or `ET_ENV`. `*-pr
 excluded by default for the local cftlib environment. Set `CCD_DEF_EXCLUDED_FILENAME_PATTERNS` to a
 comma-separated list of glob patterns to override this.
 
+If an ancestor of the JSON directory contains `configs/environment/env.json`, cftlib loads its `cftlib`
+values before applying process environment variables and system properties. Set `ET_ENV` to select a
+different entry. Imports fail when a supported environment placeholder remains unresolved.
+
 If the JSON directory has a sibling `data/ccd-template.xlsx`, its sheet names and columns are used in the
 same way as the JSON-to-XLSX processor. This supports definitions whose physical template sheet name differs
 from its CCD sheet name and ensures unknown JSON properties are ignored consistently.

--- a/cftlib/lib/cftlib-agent/build.gradle
+++ b/cftlib/lib/cftlib-agent/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     compileOnly('com.github.hmcts.rse-cft-lib:excel-importer:DEV-SNAPSHOT') {
         transitive = false
     }
+    compileOnly 'org.apache.poi:poi-ooxml:5.5.1'
 
     // Provide definition store parser classes for tests.
     testImplementation('com.github.hmcts.rse-cft-lib:excel-importer:DEV-SNAPSHOT') {

--- a/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/definitionstore/JsonDefinitionReader.java
+++ b/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/definitionstore/JsonDefinitionReader.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.rse.ccd.lib.definitionstore;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.stereotype.Component;
@@ -18,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.FileSystems;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -27,14 +30,17 @@ import java.time.format.DateTimeFormatter;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static java.util.Arrays.asList;
 
 /**
  * Adds json definition parsing to CCD definition store.
@@ -49,6 +55,13 @@ public class JsonDefinitionReader extends SpreadsheetParser {
             .collect(Collectors.toList());
 
     private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final String EXCLUDED_FILENAME_PATTERNS = "CCD_DEF_EXCLUDED_FILENAME_PATTERNS";
+
+    private static final Map<String, List<String>> SHEET_PATHS = Map.of(
+            "EventToComplexTypes", List.of("EventToComplexTypes", "CaseEventToComplexTypes"),
+            "SearchCasesResultFields", List.of("SearchCasesResultFields", "SearchCaseResultFields")
+    );
 
     @Autowired
     public JsonDefinitionReader(SpreadsheetValidator spreadsheetValidator) {
@@ -66,7 +79,18 @@ public class JsonDefinitionReader extends SpreadsheetParser {
         var path =  new String(data);
         try {
             if (Path.of(path).toFile().exists()) {
-                return fromJson(path);
+                var jsonDefinition = fromJson(path);
+                var template = findTemplate(path);
+                if (template != null) {
+                    Map<String, DefinitionSheet> definition = super.parse(Files.newInputStream(template));
+                    jsonDefinition.forEach((sheetName, sheet) -> {
+                        if (!sheet.getDataItems().isEmpty() || !definition.containsKey(sheetName)) {
+                            definition.put(sheetName, sheet);
+                        }
+                    });
+                    return definition;
+                }
+                return jsonDefinition;
             }
         } catch (InvalidPathException i) {
             // Treat it as xlsx
@@ -83,89 +107,274 @@ public class JsonDefinitionReader extends SpreadsheetParser {
     }
 
     @SneakyThrows
-    public static List<Map<String, String>> readPath(String path) {
+    public static List<Map<String, Object>> readPath(String path) {
         var fi = Paths.get(path).toFile();
         List<File> files = new ArrayList<>();
         if (fi.exists()) {
-            files = Files.walk(fi.toPath())
-                    .filter(Files::isRegularFile)
-                    .map(Path::toFile)
-                    .sorted()
-                    .collect(Collectors.toList());
+            try (var paths = Files.walk(fi.toPath())) {
+                files = paths
+                        .filter(Files::isRegularFile)
+                        .map(Path::toFile)
+                        .sorted(JsonDefinitionReader::compareJsonFiles)
+                        .collect(Collectors.toList());
+            }
         }
         final var file = Paths.get(path + ".json").toFile();
 
         files.add(file);
 
-        return files.parallelStream()
-                .filter(f -> f.exists() && f.getName().endsWith(".json") && f.canRead())
+        return files.stream()
+                .filter(f -> f.exists() && f.getName().endsWith(".json") && f.canRead() && !isExcluded(f))
                 .flatMap(JsonDefinitionReader::readFile)
                 .collect(Collectors.toList());
     }
 
-    private static final Map<String, String> defEnvVars = System.getenv().entrySet().stream()
-            .filter((e) -> e.getKey().startsWith("CCD_DEF"))
-            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+    private static int compareJsonFiles(File first, File second) {
+        var firstName = first.getName().replaceFirst("\\.json$", "");
+        var secondName = second.getName().replaceFirst("\\.json$", "");
+        if (secondName.startsWith(firstName)) {
+            return -1;
+        }
+        if (firstName.startsWith(secondName)) {
+            return 1;
+        }
+        return first.getPath().compareTo(second.getPath());
+    }
 
-    @SneakyThrows
-    private static Stream<Map<String, String>> readFile(File file) {
-        var s = FileUtils.readFileToString(file);
-        // TODO - this is highly inefficient and may become a performance bottleneck if a project uses lots of env vars.
-        for (var entry : defEnvVars.entrySet()) {
-            s = s.replace("${" + entry.getKey() + "}", entry.getValue());
+    private static boolean isExcluded(File file) {
+        var configuredPatterns = System.getProperty(EXCLUDED_FILENAME_PATTERNS);
+        if (configuredPatterns == null) {
+            configuredPatterns = System.getenv(EXCLUDED_FILENAME_PATTERNS);
+        }
+        if (configuredPatterns == null) {
+            configuredPatterns = "*-prod.json";
         }
 
-        List<Map<String, String>> entries = asList(mapper.readValue(s, Map[].class));
-
-        return entries.stream();
+        return Arrays.stream(configuredPatterns.split(","))
+                .map(String::trim)
+                .filter(pattern -> !pattern.isEmpty())
+                .map(pattern -> FileSystems.getDefault().getPathMatcher("glob:" + pattern))
+                .anyMatch(matcher -> matcher.matches(file.toPath().getFileName()));
     }
 
     @SneakyThrows
-    public static Map<String, List<Map<String, String>>> toJson(final String path) {
-        return FILES.parallelStream()
-                .map(file -> {
-                    var p = file;
-                    // quick hack since this sheet's name doesn't follow convention.
-                    if (file.equals("EventToComplexTypes")) {
-                        p = "CaseEventToComplexTypes";
-                    }
-                    return new AbstractMap.SimpleEntry<>(file, JsonDefinitionReader.readPath(path + "/" + p));
-                })
-                .collect(Collectors.toUnmodifiableMap(AbstractMap.SimpleEntry::getKey,
-                        AbstractMap.SimpleEntry::getValue));
+    private static Stream<Map<String, Object>> readFile(File file) {
+        var s = FileUtils.readFileToString(file);
+        for (var entry : definitionEnvironmentVariables().entrySet()) {
+            s = s.replace("${" + entry.getKey() + "}", entry.getValue());
+        }
+
+        List<Map<String, Object>> entries = mapper.readValue(
+                s,
+                new TypeReference<List<Map<String, Object>>>() { }
+        );
+
+        return entries.stream().flatMap(JsonDefinitionReader::expandAccessControl);
+    }
+
+    private static Map<String, String> definitionEnvironmentVariables() {
+        var result = new LinkedHashMap<String, String>();
+        addDefinitionEnvironmentVariables(result, System.getenv());
+
+        Properties properties = System.getProperties();
+        properties.stringPropertyNames().stream()
+                .filter(JsonDefinitionReader::isDefinitionEnvironmentVariable)
+                .forEach(key -> result.put(key, properties.getProperty(key)));
+        return result;
+    }
+
+    private static void addDefinitionEnvironmentVariables(Map<String, String> result, Map<String, String> values) {
+        values.entrySet().stream()
+                .filter(entry -> isDefinitionEnvironmentVariable(entry.getKey()))
+                .forEach(entry -> result.put(entry.getKey(), entry.getValue()));
+    }
+
+    private static boolean isDefinitionEnvironmentVariable(String name) {
+        return name.startsWith("CCD_DEF") || name.startsWith("ET_COS") || name.startsWith("ET_ENV");
+    }
+
+    private static Stream<Map<String, Object>> expandAccessControl(Map<String, Object> row) {
+        var accessControl = row.get("AccessControl");
+        if (accessControl != null) {
+            if (!(accessControl instanceof Collection<?> controls) || controls.isEmpty()) {
+                throw new IllegalArgumentException("AccessControl must be a non-empty array");
+            }
+            if (row.containsKey("UserRole") || row.containsKey("CRUD")) {
+                throw new IllegalArgumentException("AccessControl cannot be combined with UserRole or CRUD");
+            }
+
+            return controls.stream().flatMap(control -> {
+                if (!(control instanceof Map<?, ?> values)) {
+                    throw new IllegalArgumentException("AccessControl entries must be objects");
+                }
+                return expandUserRoles(row, values.get("UserRoles"), values.get("CRUD"), "AccessControl", true);
+            });
+        }
+
+        var userRoles = row.get("UserRoles");
+        if (userRoles != null) {
+            if (row.containsKey("UserRole")) {
+                throw new IllegalArgumentException("UserRoles cannot be combined with UserRole");
+            }
+            return expandUserRoles(row, userRoles, row.get("CRUD"), "UserRoles", false);
+        }
+        return Stream.of(row);
+    }
+
+    private static Stream<Map<String, Object>> expandUserRoles(
+            Map<String, Object> source,
+            Object userRoles,
+            Object crud,
+            String sourceField,
+            boolean crudRequired
+    ) {
+        if (!(userRoles instanceof Collection<?> roles) || roles.isEmpty()) {
+            throw new IllegalArgumentException(sourceField + " requires a non-empty UserRoles array");
+        }
+        if (crudRequired && (crud == null || crud.toString().isBlank())) {
+            throw new IllegalArgumentException(sourceField + " requires a non-empty CRUD value");
+        }
+
+        return roles.stream().map(role -> {
+            var expanded = new LinkedHashMap<>(source);
+            expanded.remove("AccessControl");
+            expanded.remove("UserRoles");
+            expanded.put("UserRole", role);
+            expanded.put("CRUD", crud);
+            return expanded;
+        });
+    }
+
+    @SneakyThrows
+    public static Map<String, List<Map<String, Object>>> toJson(final String path) {
+        var templateSheetPaths = templateSheetPaths(path);
+        return FILES.stream()
+                .map(file -> new AbstractMap.SimpleEntry<>(
+                        file,
+                        JsonDefinitionReader.readPath(resolveSheetPath(path, file, templateSheetPaths))
+                ))
+                .collect(Collectors.toMap(
+                    AbstractMap.SimpleEntry::getKey,
+                    AbstractMap.SimpleEntry::getValue,
+                    (left, right) -> left,
+                    LinkedHashMap::new
+                ));
+    }
+
+    private static String resolveSheetPath(
+            String root,
+            String sheetName,
+            Map<String, String> templateSheetPaths
+    ) {
+        var candidates = new ArrayList<>(SHEET_PATHS.getOrDefault(sheetName, List.of(sheetName)));
+        var templatePath = templateSheetPaths.get(sheetName);
+        if (templatePath != null && !candidates.contains(templatePath)) {
+            candidates.add(templatePath);
+        }
+        return candidates.stream()
+                .map(candidate -> pathFor(root, candidate))
+                .filter(JsonDefinitionReader::pathExists)
+                .findFirst()
+                .orElseGet(() -> pathFor(root, candidates.get(0)));
+    }
+
+    @SneakyThrows
+    private static Map<String, String> templateSheetPaths(String jsonPath) {
+        var template = findTemplate(jsonPath);
+        if (template == null) {
+            return Map.of();
+        }
+
+        var result = new HashMap<String, String>();
+        try (var input = Files.newInputStream(template); var workbook = new XSSFWorkbook(input)) {
+            workbook.sheetIterator().forEachRemaining(sheet -> {
+                var firstRow = sheet.getRow(0);
+                if (firstRow != null && firstRow.getCell(0) != null) {
+                    result.put(firstRow.getCell(0).getStringCellValue(), sheet.getSheetName());
+                }
+            });
+        }
+        return result;
+    }
+
+    @SneakyThrows
+    private static Map<String, Set<String>> templateSheetHeaders(String jsonPath) {
+        var template = findTemplate(jsonPath);
+        if (template == null) {
+            return Map.of();
+        }
+
+        var result = new HashMap<String, Set<String>>();
+        try (var input = Files.newInputStream(template); var workbook = new XSSFWorkbook(input)) {
+            workbook.sheetIterator().forEachRemaining(sheet -> {
+                var firstRow = sheet.getRow(0);
+                var headerRow = sheet.getRow(2);
+                if (firstRow != null && firstRow.getCell(0) != null && headerRow != null) {
+                    var headers = new LinkedHashSet<String>();
+                    headerRow.cellIterator().forEachRemaining(cell -> {
+                        var value = cell.getStringCellValue();
+                        if (!value.isBlank()) {
+                            headers.add(value);
+                        }
+                    });
+                    result.put(firstRow.getCell(0).getStringCellValue(), headers);
+                }
+            });
+        }
+        return result;
+    }
+
+    private static Path findTemplate(String jsonPath) {
+        var jsonDirectory = Paths.get(jsonPath).toAbsolutePath().normalize();
+        var jurisdictionDirectory = jsonDirectory.getParent();
+        if (jurisdictionDirectory == null) {
+            return null;
+        }
+        var template = jurisdictionDirectory.resolve("data/ccd-template.xlsx");
+        return Files.isRegularFile(template) ? template : null;
+    }
+
+    private static String pathFor(String root, String sheetName) {
+        return Paths.get(root, sheetName).toString();
+    }
+
+    private static boolean pathExists(String path) {
+        return Files.exists(Paths.get(path)) || Files.exists(Paths.get(path + ".json"));
     }
 
     public static Map<String, DefinitionSheet> fromJson(String path) {
         Map<String, DefinitionSheet> result = new HashMap<>();
         var j = toJson(path);
+        var templateHeaders = templateSheetHeaders(path);
         final var dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
         for (String s : j.keySet()) {
             var sheet = j.get(s);
             var defSheet = new DefinitionSheet();
             defSheet.setName(s);
             result.put(s, defSheet);
-            for (Map<String, String> row : sheet) {
+            for (Map<String, Object> row : sheet) {
                 var item = new DefinitionDataItem(s);
                 defSheet.getDataItems().add(item);
                 for (String s1 : row.keySet()) {
+                    if (templateHeaders.containsKey(s) && !templateHeaders.get(s).contains(s1)) {
+                        continue;
+                    }
                     Object val = row.get(s1);
                     // Match the behaviour of apache's spreadsheet parser
                     if (null != val) {
                         // Numbers are expected to be strings
-                        if (val.getClass().equals(Integer.class)) {
+                        if (val instanceof Number) {
                             val = val.toString();
-                        }
-                        if (s1.equals("LiveFrom") || s1.equals("LiveTo")) {
-                            var ld = LocalDate.parse(val.toString(), dateFormatter);
-                            val = Date.from(ld.atStartOfDay(ZoneId.of("UTC")).toInstant());
                         }
                         if (val.toString().contains("\r")) {
                             val = val.toString().replace("\r", "");
                         }
-                        if (val.getClass().equals(String.class)) {
-                            if (((String) val).isEmpty()) {
-                                val = null;
-                            }
+                        if (val instanceof String stringValue && stringValue.isEmpty()) {
+                            val = null;
+                        }
+                        if (val != null && (s1.equals("LiveFrom") || s1.equals("LiveTo"))) {
+                            var ld = LocalDate.parse(val.toString(), dateFormatter);
+                            val = Date.from(ld.atStartOfDay(ZoneId.of("UTC")).toInstant());
                         }
                     }
                     item.addAttribute(s1, val);

--- a/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/definitionstore/JsonDefinitionReader.java
+++ b/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/definitionstore/JsonDefinitionReader.java
@@ -39,6 +39,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -56,7 +59,16 @@ public class JsonDefinitionReader extends SpreadsheetParser {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
+    private static final Logger LOG = Logger.getLogger(JsonDefinitionReader.class.getName());
+
     private static final String EXCLUDED_FILENAME_PATTERNS = "CCD_DEF_EXCLUDED_FILENAME_PATTERNS";
+
+    private static final String ET_ENV = "ET_ENV";
+
+    private static final Pattern UNRESOLVED_ENVIRONMENT_VARIABLE =
+            Pattern.compile("\\$\\{(?:CCD_DEF|ET_COS|ET_ENV)[^}]*}");
+
+    private final SpreadsheetValidator spreadsheetValidator;
 
     private static final Map<String, List<String>> SHEET_PATHS = Map.of(
             "EventToComplexTypes", List.of("EventToComplexTypes", "CaseEventToComplexTypes"),
@@ -66,6 +78,7 @@ public class JsonDefinitionReader extends SpreadsheetParser {
     @Autowired
     public JsonDefinitionReader(SpreadsheetValidator spreadsheetValidator) {
         super(spreadsheetValidator);
+        this.spreadsheetValidator = spreadsheetValidator;
     }
 
     /**
@@ -79,7 +92,7 @@ public class JsonDefinitionReader extends SpreadsheetParser {
         var path =  new String(data);
         try {
             if (Path.of(path).toFile().exists()) {
-                var jsonDefinition = fromJson(path);
+                var jsonDefinition = fromJson(path, spreadsheetValidator);
                 var template = findTemplate(path);
                 if (template != null) {
                     Map<String, DefinitionSheet> definition = super.parse(Files.newInputStream(template));
@@ -108,6 +121,7 @@ public class JsonDefinitionReader extends SpreadsheetParser {
 
     @SneakyThrows
     public static List<Map<String, Object>> readPath(String path) {
+        var environmentVariables = definitionEnvironmentVariables(path);
         var fi = Paths.get(path).toFile();
         List<File> files = new ArrayList<>();
         if (fi.exists()) {
@@ -125,13 +139,16 @@ public class JsonDefinitionReader extends SpreadsheetParser {
 
         return files.stream()
                 .filter(f -> f.exists() && f.getName().endsWith(".json") && f.canRead() && !isExcluded(f))
-                .flatMap(JsonDefinitionReader::readFile)
+                .flatMap(fileToRead -> readFile(fileToRead, environmentVariables))
                 .collect(Collectors.toList());
     }
 
     private static int compareJsonFiles(File first, File second) {
         var firstName = first.getName().replaceFirst("\\.json$", "");
         var secondName = second.getName().replaceFirst("\\.json$", "");
+        if (firstName.equals(secondName)) {
+            return first.getPath().compareTo(second.getPath());
+        }
         if (secondName.startsWith(firstName)) {
             return -1;
         }
@@ -158,10 +175,16 @@ public class JsonDefinitionReader extends SpreadsheetParser {
     }
 
     @SneakyThrows
-    private static Stream<Map<String, Object>> readFile(File file) {
+    private static Stream<Map<String, Object>> readFile(File file, Map<String, String> environmentVariables) {
         var s = FileUtils.readFileToString(file);
-        for (var entry : definitionEnvironmentVariables().entrySet()) {
+        for (var entry : environmentVariables.entrySet()) {
             s = s.replace("${" + entry.getKey() + "}", entry.getValue());
+        }
+        var unresolvedVariable = UNRESOLVED_ENVIRONMENT_VARIABLE.matcher(s);
+        if (unresolvedVariable.find()) {
+            throw new IllegalArgumentException(
+                    "Unresolved definition environment variable " + unresolvedVariable.group() + " in " + file
+            );
         }
 
         List<Map<String, Object>> entries = mapper.readValue(
@@ -172,8 +195,9 @@ public class JsonDefinitionReader extends SpreadsheetParser {
         return entries.stream().flatMap(JsonDefinitionReader::expandAccessControl);
     }
 
-    private static Map<String, String> definitionEnvironmentVariables() {
+    private static Map<String, String> definitionEnvironmentVariables(String definitionPath) {
         var result = new LinkedHashMap<String, String>();
+        addDefinitionEnvironmentConfig(result, definitionPath);
         addDefinitionEnvironmentVariables(result, System.getenv());
 
         Properties properties = System.getProperties();
@@ -181,6 +205,42 @@ public class JsonDefinitionReader extends SpreadsheetParser {
                 .filter(JsonDefinitionReader::isDefinitionEnvironmentVariable)
                 .forEach(key -> result.put(key, properties.getProperty(key)));
         return result;
+    }
+
+    private static void addDefinitionEnvironmentConfig(Map<String, String> result, String definitionPath) {
+        var config = findDefinitionEnvironmentConfig(definitionPath);
+        if (config == null) {
+            return;
+        }
+
+        try {
+            Map<String, Map<String, String>> environments = mapper.readValue(
+                    config.toFile(),
+                    new TypeReference<Map<String, Map<String, String>>>() { }
+            );
+            var environment = System.getProperty(ET_ENV, System.getenv().getOrDefault(ET_ENV, "cftlib"));
+            var values = environments.get(environment);
+            if (values != null) {
+                addDefinitionEnvironmentVariables(result, values);
+            }
+        } catch (IOException exception) {
+            LOG.log(Level.WARNING, "Could not load definition environment config from " + config, exception);
+        }
+    }
+
+    private static Path findDefinitionEnvironmentConfig(String definitionPath) {
+        var current = Paths.get(definitionPath).toAbsolutePath().normalize();
+        if (Files.isRegularFile(current)) {
+            current = current.getParent();
+        }
+        while (current != null) {
+            var config = current.resolve("configs/environment/env.json");
+            if (Files.isRegularFile(config)) {
+                return config;
+            }
+            current = current.getParent();
+        }
+        return null;
     }
 
     private static void addDefinitionEnvironmentVariables(Map<String, String> result, Map<String, String> values) {
@@ -343,16 +403,23 @@ public class JsonDefinitionReader extends SpreadsheetParser {
     }
 
     public static Map<String, DefinitionSheet> fromJson(String path) {
+        return fromJson(path, null);
+    }
+
+    private static Map<String, DefinitionSheet> fromJson(String path, SpreadsheetValidator spreadsheetValidator) {
         Map<String, DefinitionSheet> result = new HashMap<>();
         var j = toJson(path);
         var templateHeaders = templateSheetHeaders(path);
+        var templatePaths = templateSheetPaths(path);
         final var dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
         for (String s : j.keySet()) {
             var sheet = j.get(s);
+            var validationSheetName = templatePaths.getOrDefault(s, s);
             var defSheet = new DefinitionSheet();
             defSheet.setName(s);
             result.put(s, defSheet);
-            for (Map<String, Object> row : sheet) {
+            for (var rowIndex = 0; rowIndex < sheet.size(); rowIndex++) {
+                Map<String, Object> row = sheet.get(rowIndex);
                 var item = new DefinitionDataItem(s);
                 defSheet.getDataItems().add(item);
                 for (String s1 : row.keySet()) {
@@ -376,6 +443,9 @@ public class JsonDefinitionReader extends SpreadsheetParser {
                             var ld = LocalDate.parse(val.toString(), dateFormatter);
                             val = Date.from(ld.atStartOfDay(ZoneId.of("UTC")).toInstant());
                         }
+                    }
+                    if (spreadsheetValidator != null && val instanceof String stringValue) {
+                        spreadsheetValidator.validate(validationSheetName, s1, stringValue, rowIndex + 4);
                     }
                     item.addAttribute(s1, val);
                 }

--- a/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/definitionstore/JsonDefinitionReader.java
+++ b/cftlib/lib/cftlib-agent/src/main/java/uk/gov/hmcts/rse/ccd/lib/definitionstore/JsonDefinitionReader.java
@@ -144,18 +144,9 @@ public class JsonDefinitionReader extends SpreadsheetParser {
     }
 
     private static int compareJsonFiles(File first, File second) {
-        var firstName = first.getName().replaceFirst("\\.json$", "");
-        var secondName = second.getName().replaceFirst("\\.json$", "");
-        if (firstName.equals(secondName)) {
-            return first.getPath().compareTo(second.getPath());
-        }
-        if (secondName.startsWith(firstName)) {
-            return -1;
-        }
-        if (firstName.startsWith(secondName)) {
-            return 1;
-        }
-        return first.getPath().compareTo(second.getPath());
+        var firstPath = first.getPath().replaceFirst("\\.json$", "");
+        var secondPath = second.getPath().replaceFirst("\\.json$", "");
+        return firstPath.compareTo(secondPath);
     }
 
     private static boolean isExcluded(File file) {

--- a/cftlib/lib/cftlib-agent/src/test/java/uk/gov/hmcts/rse/ccd/lib/model/JsonDefinitionReaderTest.java
+++ b/cftlib/lib/cftlib-agent/src/test/java/uk/gov/hmcts/rse/ccd/lib/model/JsonDefinitionReaderTest.java
@@ -3,7 +3,9 @@ package uk.gov.hmcts.rse.ccd.lib.model;
 import com.google.common.collect.Sets;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.opentest4j.AssertionFailedError;
 import uk.gov.hmcts.ccd.definition.store.excel.endpoint.exception.MapperException;
 import uk.gov.hmcts.ccd.definition.store.excel.parser.SpreadsheetParser;
@@ -14,6 +16,8 @@ import uk.gov.hmcts.ccd.definition.store.excel.validation.SpreadsheetValidator;
 import uk.gov.hmcts.rse.ccd.lib.definitionstore.JsonDefinitionReader;
 
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -23,6 +27,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class JsonDefinitionReaderTest {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     public void readsFileAndDirectory() {
@@ -69,6 +76,194 @@ class JsonDefinitionReaderTest {
         var expected = loadReferenceXlsx().get("ComplexTypes").groupDataItemsById();
         var actual = loadJsonDefinition().get("ComplexTypes").groupDataItemsById();
         assertThat(new ArrayList<>(actual.keySet())).isEqualTo(new ArrayList<>(expected.keySet()));
+    }
+
+    @Test
+    @SneakyThrows
+    void supportsDefinitionProcessorSheetNames() {
+        Files.createDirectories(tempDir.resolve("EventToComplexTypes"));
+        Files.writeString(
+                tempDir.resolve("EventToComplexTypes/EventToComplexTypes.json"),
+                """
+                [{"ID":"event","FieldDisplayOrder":1}]
+                """
+        );
+        Files.writeString(
+                tempDir.resolve("SearchCaseResultFields.json"),
+                """
+                [{"CaseTypeID":"case-type","CaseFieldID":"field"}]
+                """
+        );
+
+        var result = JsonDefinitionReader.toJson(tempDir.toString());
+
+        assertThat(result.get("EventToComplexTypes")).hasSize(1);
+        assertThat(result.get("SearchCasesResultFields")).hasSize(1);
+    }
+
+    @Test
+    @SneakyThrows
+    void usesTemplateSheetNamesForJsonDirectories() {
+        var jsonDirectory = Files.createDirectories(tempDir.resolve("json"));
+        var dataDirectory = Files.createDirectories(tempDir.resolve("data"));
+        Files.createDirectories(jsonDirectory.resolve("EnglandWales Scrubbed"));
+        Files.writeString(
+                jsonDirectory.resolve("EnglandWales Scrubbed/EnglandWales Scrubbed.json"),
+                """
+                [{"ID":"fixed-list","ListElementCode":"value","ListElement":"Value","DisplayOrder":1}]
+                """
+        );
+
+        try (var workbook = new XSSFWorkbook();
+             var output = Files.newOutputStream(dataDirectory.resolve("ccd-template.xlsx"))) {
+            var sheet = workbook.createSheet("EnglandWales Scrubbed");
+            sheet.createRow(0).createCell(0).setCellValue("FixedLists");
+            workbook.write(output);
+        }
+
+        var result = JsonDefinitionReader.toJson(jsonDirectory.toString());
+
+        assertThat(result.get("FixedLists")).hasSize(1);
+        assertThat(result.get("FixedLists").get(0).get("ID")).isEqualTo("fixed-list");
+    }
+
+    @Test
+    @SneakyThrows
+    void ignoresJsonPropertiesThatAreNotTemplateColumns() {
+        var jsonDirectory = Files.createDirectories(tempDir.resolve("json"));
+        var dataDirectory = Files.createDirectories(tempDir.resolve("data"));
+        Files.writeString(
+                jsonDirectory.resolve("CaseEventToFields.json"),
+                """
+                [{"CaseFieldID":"field","retainHiddenValue":"Yes"}]
+                """
+        );
+
+        try (var workbook = new XSSFWorkbook();
+             var output = Files.newOutputStream(dataDirectory.resolve("ccd-template.xlsx"))) {
+            var sheet = workbook.createSheet("CaseEventToFields");
+            sheet.createRow(0).createCell(0).setCellValue("CaseEventToFields");
+            var headers = sheet.createRow(2);
+            headers.createCell(0).setCellValue("CaseFieldID");
+            headers.createCell(1).setCellValue("RetainHiddenValue");
+            workbook.write(output);
+        }
+
+        var item = JsonDefinitionReader.fromJson(jsonDirectory.toString())
+                .get("CaseEventToFields")
+                .getDataItems()
+                .get(0);
+
+        assertThat(item.getCaseFieldId()).isEqualTo("field");
+        assertThat(item.findAttribute(ColumnName.RETAIN_HIDDEN_VALUE)).isNull();
+    }
+
+    @Test
+    @SneakyThrows
+    void excludesProductionFragmentsByDefault() {
+        Files.createDirectories(tempDir.resolve("CaseEvent"));
+        Files.writeString(
+                tempDir.resolve("CaseEvent/CaseEvent.json"),
+                """
+                [{"ID":"base"}]
+                """
+        );
+        Files.writeString(
+                tempDir.resolve("CaseEvent/CaseEvent-prod.json"),
+                """
+                [{"ID":"prod"}]
+                """
+        );
+        Files.writeString(
+                tempDir.resolve("CaseEvent/CaseEvent-nonprod.json"),
+                """
+                [{"ID":"nonprod"}]
+                """
+        );
+
+        var result = JsonDefinitionReader.readPath(tempDir.resolve("CaseEvent").toString());
+
+        assertThat(result).extracting(row -> row.get("ID")).containsExactly("base", "nonprod");
+    }
+
+    @Test
+    @SneakyThrows
+    void expandsDefinitionProcessorAccessControlShorthand() {
+        Files.writeString(
+                tempDir.resolve("AuthorisationCaseEvent.json"),
+                """
+                [{
+                  "CaseTypeID":"case-type",
+                  "CaseEventID":"event",
+                  "AccessControl":[
+                    {"UserRoles":["role-a","role-b"],"CRUD":"CRUD"},
+                    {"UserRoles":["role-c"],"CRUD":"R"}
+                  ]
+                }]
+                """
+        );
+
+        var result = JsonDefinitionReader.toJson(tempDir.toString()).get("AuthorisationCaseEvent");
+
+        assertThat(result).extracting(row -> row.get("UserRole"))
+                .containsExactly("role-a", "role-b", "role-c");
+        assertThat(result).extracting(row -> row.get("CRUD"))
+                .containsExactly("CRUD", "CRUD", "R");
+        assertThat(result).allSatisfy(row -> assertThat(row).doesNotContainKey("AccessControl"));
+    }
+
+    @Test
+    @SneakyThrows
+    void expandsUserRolesWithoutRequiringCrud() {
+        Files.writeString(
+                tempDir.resolve("AuthorisationCaseType.json"),
+                """
+                [{"CaseTypeID":"case-type","UserRoles":["role-a","role-b"]}]
+                """
+        );
+
+        var result = JsonDefinitionReader.toJson(tempDir.toString()).get("AuthorisationCaseType");
+
+        assertThat(result).extracting(row -> row.get("UserRole")).containsExactly("role-a", "role-b");
+    }
+
+    @Test
+    @SneakyThrows
+    void substitutesEtDefinitionEnvironmentProperties() {
+        Files.writeString(
+                tempDir.resolve("CaseType.json"),
+                """
+                [{"ID":"case-type","PrintableDocumentsUrl":"${ET_COS_URL}/documents"}]
+                """
+        );
+        System.setProperty("ET_COS_URL", "http://localhost:8081");
+        try {
+            var result = JsonDefinitionReader.readPath(tempDir.resolve("CaseType").toString());
+
+            assertThat(result.get(0).get("PrintableDocumentsUrl"))
+                    .isEqualTo("http://localhost:8081/documents");
+        } finally {
+            System.clearProperty("ET_COS_URL");
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void treatsEmptyJsonDatesAsSpreadsheetBlanks() {
+        Files.writeString(
+                tempDir.resolve("CaseType.json"),
+                """
+                [{"ID":"case-type","LiveFrom":"01/01/2017","LiveTo":""}]
+                """
+        );
+
+        var item = JsonDefinitionReader.fromJson(tempDir.toString())
+                .get("CaseType")
+                .getDataItems()
+                .get(0);
+
+        assertThat(item.findAttribute(ColumnName.LIVE_FROM)).isNotNull();
+        assertThat(item.findAttribute(ColumnName.LIVE_TO)).isNull();
     }
 
     /**

--- a/cftlib/lib/cftlib-agent/src/test/java/uk/gov/hmcts/rse/ccd/lib/model/JsonDefinitionReaderTest.java
+++ b/cftlib/lib/cftlib-agent/src/test/java/uk/gov/hmcts/rse/ccd/lib/model/JsonDefinitionReaderTest.java
@@ -319,6 +319,21 @@ class JsonDefinitionReaderTest {
 
     @Test
     @SneakyThrows
+    void sortsNestedFragmentsWithOneTotalPathOrdering() {
+        var sheetDirectory = Files.createDirectories(tempDir.resolve("CaseEvent"));
+        var firstDirectory = Files.createDirectories(sheetDirectory.resolve("a"));
+        var secondDirectory = Files.createDirectories(sheetDirectory.resolve("b"));
+        Files.writeString(firstDirectory.resolve("AB.json"), "[{\"ID\":\"first\"}]");
+        Files.writeString(firstDirectory.resolve("B.json"), "[{\"ID\":\"second\"}]");
+        Files.writeString(secondDirectory.resolve("A.json"), "[{\"ID\":\"third\"}]");
+
+        var result = JsonDefinitionReader.readPath(sheetDirectory.toString());
+
+        assertThat(result).extracting(row -> row.get("ID")).containsExactly("first", "second", "third");
+    }
+
+    @Test
+    @SneakyThrows
     void validatesJsonCellsLikeSpreadsheetCells() {
         Files.writeString(
                 tempDir.resolve("Jurisdiction.json"),

--- a/cftlib/lib/cftlib-agent/src/test/java/uk/gov/hmcts/rse/ccd/lib/model/JsonDefinitionReaderTest.java
+++ b/cftlib/lib/cftlib-agent/src/test/java/uk/gov/hmcts/rse/ccd/lib/model/JsonDefinitionReaderTest.java
@@ -19,7 +19,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -273,51 +273,38 @@ class JsonDefinitionReaderTest {
     private void assertSheetsEqual(DefinitionSheet expected, DefinitionSheet actual) {
         assertThat(expected.getName()).isEqualTo(actual.getName());
         assertThat(actual.getDataItems().size()).isEqualTo(expected.getDataItems().size());
-        expected.getDataItems().sort(Comparator.comparing(this::extractSortKey));
-        actual.getDataItems().sort(Comparator.comparing(this::extractSortKey));
-        for (int t = 0; t < expected.getDataItems().size(); t++) {
-            assertItemsEqual(actual.getDataItems().get(t), expected.getDataItems().get(t));
+        Map<String, List<DefinitionDataItem>> unmatchedItems = new HashMap<>();
+        actual.getDataItems().forEach(item ->
+                unmatchedItems.computeIfAbsent(matchKey(item), key -> new ArrayList<>()).add(item)
+        );
+        for (DefinitionDataItem expectedItem : expected.getDataItems()) {
+            var candidates = unmatchedItems.getOrDefault(matchKey(expectedItem), List.of());
+            var matchingItem = candidates.stream()
+                    .filter(actualItem -> itemsEqual(actualItem, expectedItem))
+                    .findFirst();
+            assertThat(matchingItem)
+                    .as("No matching row in %s for %s", expected.getName(), expectedItem.getCaseFieldId())
+                    .isPresent();
+            candidates.remove(matchingItem.orElseThrow());
         }
         System.out.println(expected.getName() + " is ok");
     }
 
-    /**
-     * Different definition sheets have different 'primary keys'
-     * ie. the columns that uniquely identify a row.
-     */
-    private List<List<ColumnName>> compoundSortKeys = List.of(
-            List.of(ColumnName.ID),
-            List.of(ColumnName.DISPLAY_ORDER),
-            List.of(ColumnName.STATE_ID),
-            List.of(ColumnName.CASE_EVENT_ID),
-            List.of(ColumnName.TAB_ID),
-            List.of(ColumnName.CASE_FIELD_ID, ColumnName.ACCESS_PROFILE)
-    );
-
-    /**
-     * Generate a string for sorting on by looking through our known
-     * list of keys and finding the first contained in the item.
-     */
-    @SneakyThrows
-    private String extractSortKey(DefinitionDataItem item) {
-        for (List<ColumnName> compoundKey : compoundSortKeys) {
-            try {
-                var sortKey = "";
-                for (ColumnName key : compoundKey) {
-                    var val = item.findAttribute(key);
-                    if (null != val) {
-                        sortKey += val;
-                    }
-                }
-                if (!sortKey.isEmpty()) {
-                    return sortKey;
-                }
-            } catch (MapperException m) {
-                // Expected if the key is not found for a particular item.
-            }
+    private String matchKey(DefinitionDataItem item) {
+        try {
+            return item.getCaseFieldId();
+        } catch (MapperException mapperException) {
+            return "";
         }
+    }
 
-        throw new RuntimeException("No known keys to compare: " + item.getCaseFieldId());
+    private boolean itemsEqual(DefinitionDataItem actual, DefinitionDataItem expected) {
+        try {
+            assertItemsEqual(actual, expected);
+            return true;
+        } catch (AssertionFailedError assertionFailedError) {
+            return false;
+        }
     }
 
     @SneakyThrows

--- a/cftlib/lib/cftlib-agent/src/test/java/uk/gov/hmcts/rse/ccd/lib/model/JsonDefinitionReaderTest.java
+++ b/cftlib/lib/cftlib-agent/src/test/java/uk/gov/hmcts/rse/ccd/lib/model/JsonDefinitionReaderTest.java
@@ -7,6 +7,7 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.opentest4j.AssertionFailedError;
+import uk.gov.hmcts.ccd.definition.store.excel.endpoint.exception.InvalidImportException;
 import uk.gov.hmcts.ccd.definition.store.excel.endpoint.exception.MapperException;
 import uk.gov.hmcts.ccd.definition.store.excel.parser.SpreadsheetParser;
 import uk.gov.hmcts.ccd.definition.store.excel.parser.model.DefinitionDataItem;
@@ -15,6 +16,7 @@ import uk.gov.hmcts.ccd.definition.store.excel.util.mapper.ColumnName;
 import uk.gov.hmcts.ccd.definition.store.excel.validation.SpreadsheetValidator;
 import uk.gov.hmcts.rse.ccd.lib.definitionstore.JsonDefinitionReader;
 
+import java.io.ByteArrayInputStream;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,6 +27,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JsonDefinitionReaderTest {
 
@@ -245,6 +248,90 @@ class JsonDefinitionReaderTest {
         } finally {
             System.clearProperty("ET_COS_URL");
         }
+    }
+
+    @Test
+    @SneakyThrows
+    void loadsCftlibDefinitionEnvironmentConfig() {
+        var definitionRoot = Files.createDirectories(tempDir.resolve("ccd-definitions"));
+        var jsonDirectory = Files.createDirectories(
+                definitionRoot.resolve("jurisdictions/england-wales/json")
+        );
+        var environmentDirectory = Files.createDirectories(definitionRoot.resolve("configs/environment"));
+        Files.writeString(
+                environmentDirectory.resolve("env.json"),
+                """
+                {
+                  "cftlib": {
+                    "CCD_DEF_URL": "http://localhost:4452",
+                    "CCD_DEF_AAC_URL": "http://localhost:4454"
+                  }
+                }
+                """
+        );
+        Files.writeString(
+                jsonDirectory.resolve("CaseType.json"),
+                """
+                [{"ID":"case-type","PrintableDocumentsUrl":"${CCD_DEF_URL}/documents"}]
+                """
+        );
+
+        System.setProperty("ET_ENV", "cftlib");
+        try {
+            var result = JsonDefinitionReader.readPath(jsonDirectory.resolve("CaseType").toString());
+
+            assertThat(result.get(0).get("PrintableDocumentsUrl"))
+                    .isEqualTo("http://localhost:4452/documents");
+        } finally {
+            System.clearProperty("ET_ENV");
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void rejectsUnresolvedDefinitionEnvironmentVariables() {
+        Files.writeString(
+                tempDir.resolve("CaseType.json"),
+                """
+                [{"ID":"case-type","PrintableDocumentsUrl":"${CCD_DEF_MISSING}/documents"}]
+                """
+        );
+
+        assertThrows(
+                IllegalArgumentException.class,
+            () -> JsonDefinitionReader.readPath(tempDir.resolve("CaseType").toString())
+        );
+    }
+
+    @Test
+    @SneakyThrows
+    void sortsDuplicateFragmentNamesByPath() {
+        var sheetDirectory = Files.createDirectories(tempDir.resolve("CaseEvent"));
+        var firstDirectory = Files.createDirectories(sheetDirectory.resolve("a"));
+        var secondDirectory = Files.createDirectories(sheetDirectory.resolve("b"));
+        Files.writeString(firstDirectory.resolve("fragment.json"), "[{\"ID\":\"first\"}]");
+        Files.writeString(secondDirectory.resolve("fragment.json"), "[{\"ID\":\"second\"}]");
+
+        var result = JsonDefinitionReader.readPath(sheetDirectory.toString());
+
+        assertThat(result).extracting(row -> row.get("ID")).containsExactly("first", "second");
+    }
+
+    @Test
+    @SneakyThrows
+    void validatesJsonCellsLikeSpreadsheetCells() {
+        Files.writeString(
+                tempDir.resolve("Jurisdiction.json"),
+                """
+                [{"ID":"EMPLOYMENT","Name":"This jurisdiction name is more than thirty characters long"}]
+                """
+        );
+        var reader = new JsonDefinitionReader(new SpreadsheetValidator());
+
+        assertThrows(
+                InvalidImportException.class,
+            () -> reader.parse(new ByteArrayInputStream(tempDir.toString().getBytes()))
+        );
     }
 
     @Test


### PR DESCRIPTION
### Change description ###

Extends the JSON definition reader to support the CCD definition processor conventions used by services such as ET. This covers split and aliased sheets, local exclusion of production fragments, access-control shorthand, empty dates, environment substitutions, deterministic fragment ordering, and template-defined sheet names and columns.

ET can now call `importJsonDefinition` directly instead of generating an intermediate spreadsheet. The Admin, England/Wales and Scotland definitions import successfully into a local Definition Store backed by PostgreSQL through this path.